### PR TITLE
Add component prop support, build RouteRow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,12 +3,12 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
 import { NativeBaseProvider } from 'native-base';
-import tabNameToRouteData from './utils/routes/routes';
+import { tabNameToRouteData, PropMap } from './utils/routes/routes';
 import { Name as TabName } from './utils/routes/tabs/names';
 import { routes as tabRoutes } from './utils/routes/tabs/routes';
 
 // Tabs used for bottom tray, stack for in-tab nav
-const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator<PropMap>();
 const Tabs = createBottomTabNavigator();
 
 // Builds a navigator stack for a given tab

--- a/components/route/RouteRow.tsx
+++ b/components/route/RouteRow.tsx
@@ -1,0 +1,47 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import {
+  ArrowForwardIcon,
+  Center,
+  HStack,
+  Image,
+  Text,
+  VStack,
+} from 'native-base';
+import React from 'react';
+import { PropMap } from '../../utils/routes/routes';
+
+type Props = NativeStackScreenProps<PropMap, 'RouteRow'>;
+const RouteRow = ({ route }: Props) => {
+  let description = route.params.grade;
+  route.params.tags.forEach((tag) => {
+    description = description + ', ' + tag;
+  });
+
+  return (
+    <HStack h={20} pl={2} my={3} backgroundColor="white">
+      <Center w="20%">
+        <Image
+          size={16}
+          borderRadius={5}
+          source={{ uri: route.params.thumbnail }}
+          alt={route.params.name}
+        />
+      </Center>
+      <Center w="65%">
+        <VStack w="full" h="full" pl={2} pt={2}>
+          <Text fontSize="xl" fontWeight="bold">
+            {route.params.name}
+          </Text>
+          <Text fontSize="lg" color="grey">
+            {description}
+          </Text>
+        </VStack>
+      </Center>
+      <Center w="15%">
+        <ArrowForwardIcon size="5" />
+      </Center>
+    </HStack>
+  );
+};
+
+export default RouteRow;

--- a/pages/sandbox/Sandbox.tsx
+++ b/pages/sandbox/Sandbox.tsx
@@ -1,21 +1,32 @@
-import { Button, Text, ScrollView, Box } from 'native-base';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Box, Button, ScrollView, Text } from 'native-base';
+import { PropMap } from '../../utils/routes/routes';
 import {
-  names as routeNames,
   Name as RouteName,
+  names as routeNames,
 } from '../../utils/routes/sandbox/names';
+import { PropMap as SandboxPropMap } from '../../utils/routes/sandbox/routes';
+
+// Sandbox test data
+const propMap: SandboxPropMap = {
+  Sandbox: undefined,
+  RouteRow: {
+    thumbnail: 'https://wallpaperaccess.com/full/317501.jpg',
+    name: 'Example route',
+    grade: '10.9',
+    tags: ['Solid, Dyno'],
+  },
+};
 
 // List of buttons that navigate directly to test components in a dry environment
-type Props = {
-  navigation: NativeStackNavigationProp<any, any>;
-};
+type Props = NativeStackScreenProps<PropMap, 'Sandbox'>;
 export default function Sandbox({ navigation }: Props) {
   const buildEntryButton = (routeName: RouteName) => {
     return (
       <Button
         mx="2"
         my="1"
-        onPress={() => navigation.push(routeName)}
+        onPress={() => navigation.push(routeName, propMap[routeName])}
         key={routeName}
       >
         <Text>{routeName}</Text>

--- a/utils/routes/default/names.ts
+++ b/utils/routes/default/names.ts
@@ -1,3 +1,3 @@
 // All valid route names for default tab
-export const names = ['Null'] as const;
+export const names = ['Default'] as const;
 export type Name = typeof names[number];

--- a/utils/routes/default/routes.ts
+++ b/utils/routes/default/routes.ts
@@ -9,7 +9,11 @@ export type Route = {
 
 export const routes: Array<Route> = [
   {
-    name: 'Null',
+    name: 'Default',
     component: View,
   },
 ];
+
+export type PropMap = {
+  Default: undefined;
+};

--- a/utils/routes/routes.ts
+++ b/utils/routes/routes.ts
@@ -1,12 +1,18 @@
 // Combine useful route datas, and map tabs to their routes
-import { routes as defaultRoutes } from './default/routes';
-import { routes as sandboxRoutes } from './sandbox/routes';
+import {
+  routes as defaultRoutes,
+  PropMap as DefaultPropMap,
+} from './default/routes';
+import {
+  routes as sandboxRoutes,
+  PropMap as SandboxPropMap,
+} from './sandbox/routes';
 
 import { Name as DefaultName } from './default/names';
 import { Name as SandboxName } from './sandbox/names';
 import { Name as TabName } from './tabs/names';
 
-export type RouteName = DefaultName | SandboxName | TabName;
+export type RouteName = DefaultName | SandboxName;
 export type Route = {
   name: RouteName;
   component: any;
@@ -18,7 +24,7 @@ type RouteData = {
 };
 const tabNameToRouteData: { [tabName in TabName]: RouteData } = {
   DefaultTab: {
-    initialRouteName: 'Null',
+    initialRouteName: 'Default',
     routes: defaultRoutes,
   },
   SandboxTab: {
@@ -27,4 +33,6 @@ const tabNameToRouteData: { [tabName in TabName]: RouteData } = {
   },
 };
 
-export default tabNameToRouteData;
+type PropMap = DefaultPropMap & SandboxPropMap;
+
+export { tabNameToRouteData, PropMap };

--- a/utils/routes/sandbox/names.ts
+++ b/utils/routes/sandbox/names.ts
@@ -1,3 +1,3 @@
 // All valid route names for sandbox tab
-export const names = ['Sandbox', 'Avatar'] as const;
+export const names = ['Sandbox', 'RouteRow'] as const;
 export type Name = typeof names[number];

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -1,7 +1,7 @@
 // Route metadata for the sandbox tab
 import { Name } from './names';
 import Sandbox from '../../../pages/sandbox/Sandbox';
-import { Avatar } from 'native-base';
+import RouteRow from '../../../components/route/RouteRow';
 
 export type Route = {
   name: Name;
@@ -14,7 +14,19 @@ export const routes: Array<Route> = [
     component: Sandbox,
   },
   {
-    name: 'Avatar',
-    component: Avatar,
+    name: 'RouteRow',
+    component: RouteRow,
   },
 ];
+
+export type PropMap = {
+  Sandbox: undefined;
+
+  // Maybe replace this with RouteRef backend object down the line
+  RouteRow: {
+    thumbnail: string;
+    name: string;
+    grade: string;
+    tags: Array<string>;
+  };
+};


### PR DESCRIPTION
## Props
Props are a critical part of building functional React projects, and since we are using TypeScript there is a bit of overhead to get them set up in a route enabled environment. The [React Navigation TypeScript Docs](https://reactnavigation.org/docs/typescript/) were very helpful getting this up and running.

## RouteRow
As specified in our [Routes Figma](https://www.figma.com/file/MjlTrOoFwO50FxJrQbd70K/Climbing-App----Prototypes?node-id=58%3A3734&t=12VKmZ7cMlppHAJB-0), we need a row that can represent a route in a scroll view. This component builds out this functionality.

| RouteRow with test data |
| - |
| ![image](https://user-images.githubusercontent.com/36250052/201564296-e75bbe46-845b-4851-870f-cc018a3f8df3.png) |
