### PR TITLE
Create StatBox component

### DIFF
--- a/components/profile/StatBox.tsx
+++ b/components/profile/StatBox.tsx
@@ -1,7 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Pressable, Text, VStack, Center } from 'native-base';
 import { DeviceEventEmitter } from 'react-native';
-import { PropMap } from '../../../utils/routes/routes';
+import { PropMap } from '../../utils/routes/routes';
 
 type Props = NativeStackScreenProps<PropMap, 'StatBox'>;
 const StatBox = ({ route }: Props) => {

--- a/components/profile/StatBox.tsx
+++ b/components/profile/StatBox.tsx
@@ -1,5 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Pressable, Text, VStack, Center } from 'native-base';
+import { Pressable, Text, VStack } from 'native-base';
 import { DeviceEventEmitter } from 'react-native';
 import { PropMap } from '../../utils/routes/routes';
 
@@ -19,17 +19,15 @@ const StatBox = ({ route }: Props) => {
             bg={
               isPressed ? 'coolGray.100' : isHovered ? 'coolGray.100' : 'white'
             }
+            justifyContent="center"
+            alignItems="center"
           >
-            <Center>
-              <Text fontSize="xl" color="gray.400">
-                {route.params.stat}
-              </Text>
-            </Center>
-            <Center>
-              <Text fontSize="2xl" bold>
-                {route.params.value}
-              </Text>
-            </Center>
+            <Text fontSize="xl" color="gray.400">
+              {route.params.stat}
+            </Text>
+            <Text fontSize="2xl" bold>
+              {route.params.value}
+            </Text>
           </VStack>
         );
       }}

--- a/components/profile/stats/StatBox.tsx
+++ b/components/profile/stats/StatBox.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Box, Text, VStack } from 'native-base';
-import { PropMap } from '../../../../utils/routes/routes';
+import { PropMap } from '../../../utils/routes/routes';
 
 type Props = NativeStackScreenProps<PropMap, 'StatBox'>;
 const StatBox = ({ route }: Props) => {

--- a/components/profile/stats/StatBox.tsx
+++ b/components/profile/stats/StatBox.tsx
@@ -1,16 +1,39 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Box, Text, VStack } from 'native-base';
+import { Pressable, Text, VStack, Center } from 'native-base';
+import { DeviceEventEmitter } from 'react-native';
 import { PropMap } from '../../../utils/routes/routes';
 
 type Props = NativeStackScreenProps<PropMap, 'StatBox'>;
 const StatBox = ({ route }: Props) => {
   return (
-    <Box>
-      <VStack>
-        <Text>{route.params.stat}</Text>
-        <Text>{route.params.value}</Text>
-      </VStack>
-    </Box>
+    <Pressable
+      p={2}
+      bg="white"
+      onPress={() => {
+        DeviceEventEmitter.emit(route.params.onPressEventName);
+      }}
+    >
+      {({ isHovered, isPressed }) => {
+        return (
+          <VStack
+            bg={
+              isPressed ? 'coolGray.100' : isHovered ? 'coolGray.100' : 'white'
+            }
+          >
+            <Center>
+              <Text fontSize="xl" color="gray.400">
+                {route.params.stat}
+              </Text>
+            </Center>
+            <Center>
+              <Text fontSize="2xl" bold>
+                {route.params.value}
+              </Text>
+            </Center>
+          </VStack>
+        );
+      }}
+    </Pressable>
   );
 };
 

--- a/components/route/RouteRow.tsx
+++ b/components/route/RouteRow.tsx
@@ -7,7 +7,6 @@ import {
   Text,
   VStack,
 } from 'native-base';
-import React from 'react';
 import { PropMap } from '../../utils/routes/routes';
 
 type Props = NativeStackScreenProps<PropMap, 'RouteRow'>;

--- a/components/route/profile/stats/StatBox.tsx
+++ b/components/route/profile/stats/StatBox.tsx
@@ -1,0 +1,17 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Box, Text, VStack } from 'native-base';
+import { PropMap } from '../../../../utils/routes/routes';
+
+type Props = NativeStackScreenProps<PropMap, 'StatBox'>;
+const StatBox = ({ route }: Props) => {
+  return (
+    <Box>
+      <VStack>
+        <Text>{route.params.stat}</Text>
+        <Text>{route.params.value}</Text>
+      </VStack>
+    </Box>
+  );
+};
+
+export default StatBox;

--- a/pages/sandbox/Sandbox.tsx
+++ b/pages/sandbox/Sandbox.tsx
@@ -1,5 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Box, Button, ScrollView, Text } from 'native-base';
+import { useEffect } from 'react';
+import { DeviceEventEmitter } from 'react-native';
 import { PropMap } from '../../utils/routes/routes';
 import {
   Name as RouteName,
@@ -19,14 +21,25 @@ const propMap: SandboxPropMap = {
   },
 
   StatBox: {
-    stat: 'Stat',
-    value: 'value',
+    stat: 'Boulder',
+    value: 'V5',
+    onPressEventName: 'statBox.testEvent',
   },
 };
 
 // List of buttons that navigate directly to test components in a dry environment
 type Props = NativeStackScreenProps<PropMap, 'Sandbox'>;
 export default function Sandbox({ navigation }: Props) {
+  useEffect(() => {
+    DeviceEventEmitter.addListener('statBox.testEvent', () => {
+      console.log('Statbox was pressed!');
+    });
+
+    return () => {
+      DeviceEventEmitter.removeAllListeners('statBox.testEvent');
+    };
+  }, []);
+
   const buildEntryButton = (routeName: RouteName) => {
     return (
       <Button

--- a/pages/sandbox/Sandbox.tsx
+++ b/pages/sandbox/Sandbox.tsx
@@ -10,11 +10,17 @@ import { PropMap as SandboxPropMap } from '../../utils/routes/sandbox/routes';
 // Sandbox test data
 const propMap: SandboxPropMap = {
   Sandbox: undefined,
+
   RouteRow: {
     thumbnail: 'https://wallpaperaccess.com/full/317501.jpg',
     name: 'Example route',
     grade: '10.9',
     tags: ['Solid, Dyno'],
+  },
+
+  StatBox: {
+    stat: 'Stat',
+    value: 'value',
   },
 };
 

--- a/utils/routes/sandbox/names.ts
+++ b/utils/routes/sandbox/names.ts
@@ -1,3 +1,3 @@
 // All valid route names for sandbox tab
-export const names = ['Sandbox', 'RouteRow'] as const;
+export const names = ['Sandbox', 'RouteRow', 'StatBox'] as const;
 export type Name = typeof names[number];

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -2,7 +2,7 @@
 import { Name } from './names';
 import Sandbox from '../../../pages/sandbox/Sandbox';
 import RouteRow from '../../../components/route/RouteRow';
-import StatBox from '../../../components/route/profile/stats/StatBox';
+import StatBox from '../../../components/profile/stats/StatBox';
 
 export type Route = {
   name: Name;

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -2,6 +2,7 @@
 import { Name } from './names';
 import Sandbox from '../../../pages/sandbox/Sandbox';
 import RouteRow from '../../../components/route/RouteRow';
+import StatBox from '../../../components/route/profile/stats/StatBox';
 
 export type Route = {
   name: Name;
@@ -17,16 +18,25 @@ export const routes: Array<Route> = [
     name: 'RouteRow',
     component: RouteRow,
   },
+  {
+    name: 'StatBox',
+    component: StatBox,
+  },
 ];
 
+// Verbose props may be swapped for middleware lazy-objects down the line
 export type PropMap = {
   Sandbox: undefined;
 
-  // Maybe replace this with RouteRef backend object down the line
   RouteRow: {
     thumbnail: string;
     name: string;
     grade: string;
     tags: Array<string>;
+  };
+
+  StatBox: {
+    stat: string;
+    value: string;
   };
 };

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -2,7 +2,7 @@
 import { Name } from './names';
 import Sandbox from '../../../pages/sandbox/Sandbox';
 import RouteRow from '../../../components/route/RouteRow';
-import StatBox from '../../../components/profile/stats/StatBox';
+import StatBox from '../../../components/profile/StatBox';
 
 export type Route = {
   name: Name;

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -38,5 +38,6 @@ export type PropMap = {
   StatBox: {
     stat: string;
     value: string;
+    onPressEventName: string;
   };
 };


### PR DESCRIPTION
The StatBox component will be found on the user profile, and can be used to look at an optionally interact with a statistic.

In the attached image, the StatBox fills the entire row, but this can easily be controlled by the callee, wrapping the StatBox in a Box of their desired form factor. We use event emitters rather than a direct callback to properly conform to React's navigation caching rules. Check out this [article](https://reactnavigation.org/docs/troubleshooting/#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state) for more info.

![image](https://user-images.githubusercontent.com/36250052/203242277-24de026e-8a75-4011-8e49-fde7eea13c65.png)
