### PR TITLE
Swap back to function

### DIFF
--- a/components/profile/StatBox.tsx
+++ b/components/profile/StatBox.tsx
@@ -1,18 +1,11 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Pressable, Text, VStack } from 'native-base';
-import { DeviceEventEmitter } from 'react-native';
 import { PropMap } from '../../utils/routes/routes';
 
 type Props = NativeStackScreenProps<PropMap, 'StatBox'>;
 const StatBox = ({ route }: Props) => {
   return (
-    <Pressable
-      p={2}
-      bg="white"
-      onPress={() => {
-        DeviceEventEmitter.emit(route.params.onPressEventName);
-      }}
-    >
+    <Pressable p={2} bg="white" onPress={route.params.onPress}>
       {({ isHovered, isPressed }) => {
         return (
           <VStack

--- a/pages/sandbox/Sandbox.tsx
+++ b/pages/sandbox/Sandbox.tsx
@@ -1,7 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Box, Button, ScrollView, Text } from 'native-base';
-import { useEffect } from 'react';
-import { DeviceEventEmitter } from 'react-native';
 import { PropMap } from '../../utils/routes/routes';
 import {
   Name as RouteName,
@@ -25,27 +23,19 @@ const propMap: SandboxPropMap = {
     userName: 'Tyler Hostler-Mathis',
     userHandle: 'tylerhm',
   },
-  
+
   StatBox: {
     stat: 'Boulder',
     value: 'V5',
-    onPressEventName: 'statBox.testEvent',
+    onPress: () => {
+      console.log('Statbox was pressed!');
+    },
   },
 };
 
 // List of buttons that navigate directly to test components in a dry environment
 type Props = NativeStackScreenProps<PropMap, 'Sandbox'>;
 export default function Sandbox({ navigation }: Props) {
-  useEffect(() => {
-    DeviceEventEmitter.addListener('statBox.testEvent', () => {
-      console.log('Statbox was pressed!');
-    });
-
-    return () => {
-      DeviceEventEmitter.removeAllListeners('statBox.testEvent');
-    };
-  }, []);
-
   const buildEntryButton = (routeName: RouteName) => {
     return (
       <Button

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -45,10 +45,10 @@ export type PropMap = {
     userName: string;
     userHandle: string;
   };
-  
+
   StatBox: {
     stat: string;
     value: string;
-    onPressEventName: string;
+    onPress: () => void;
   };
 };


### PR DESCRIPTION
In PR #6, I introduced the StatBox component, and passed an event handle to the component to comply to React-Navigation's prop passing requirements. After thinking, this is only an issue if the component is being navigated to as a `route` which will only happen in the SandBox.

For general use, it makes a great deal more sense to use the StatBox with a functional callback rather than an event handler. I've reverted to this style here, and all future components should also implement their actions with callbacks. The only exceptions should be made for routes.