### PR TITLE
Create Post Skeleton (missing the video player)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import { tabNameToRouteData } from './utils/routes/routes';
 import { routes as tabRoutes } from './utils/routes/tabs/routes';
 import { Name as TabName } from './utils/routes/tabs/names';
 import { ParamList as RootTabParamList } from './utils/routes/tabs/paramList';
+import 'react-native-gesture-handler';
 
 // Style for tab bar
 const tabBarStyle = {

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
   };
 };

--- a/components/media/ImageCarousel.tsx
+++ b/components/media/ImageCarousel.tsx
@@ -67,6 +67,9 @@ const ImageCarousel = ({ imageUrls }: Props) => {
         onProgressChange={(_, absoluteProgress) =>
           setFocusedIndex(Math.round(absoluteProgress))
         }
+        panGestureHandlerProps={{
+          activeOffsetX: [-10, 10],
+        }}
       />
       <Center>
         <HStack space={1.5}>

--- a/components/media/ImageCarousel.tsx
+++ b/components/media/ImageCarousel.tsx
@@ -1,0 +1,88 @@
+import {
+  Box,
+  Center,
+  HStack,
+  Image,
+  useColorModeValue,
+  VStack,
+} from 'native-base';
+import { useEffect, useState } from 'react';
+import { Dimensions, Image as ImageRN } from 'react-native';
+import Carousel from 'react-native-reanimated-carousel';
+
+type Props = {
+  imageUrls: Array<string>;
+};
+const ImageCarousel = ({ imageUrls }: Props) => {
+  const primaryColor = useColorModeValue(
+    'lightMode.primary',
+    'darkMode.primary'
+  );
+  const accentColor = useColorModeValue(
+    'lightMode.secondary',
+    'darkMode.secondary'
+  );
+
+  const width = Dimensions.get('window').width;
+  const [height, setHeight] = useState<number>(200);
+  const [focusedIndex, setFocusedIndex] = useState<number>(0);
+  const [data, setData] = useState<Array<number>>([]);
+
+  useEffect(() => {
+    if (imageUrls.length === 0) return;
+    setData([...imageUrls.keys()]);
+    ImageRN.getSize(imageUrls[0], (imageWidth, imageHeight) => {
+      const aspectRatio = imageWidth / imageHeight;
+      const calculatedHeight = width / aspectRatio;
+      setHeight(calculatedHeight);
+    });
+  }, [imageUrls, width]);
+
+  if (imageUrls.length === 0) return null;
+  if (imageUrls.length === 1)
+    return (
+      <Image
+        source={{ uri: imageUrls[0] }}
+        alt="Post image content"
+        width={width}
+        height={height}
+      />
+    );
+
+  return (
+    <VStack space={2} width={width}>
+      <Carousel
+        loop={false}
+        data={data}
+        width={width}
+        height={height}
+        renderItem={({ index }) => (
+          <Image
+            source={{ uri: imageUrls[index] }}
+            alt="Post image content"
+            width={width}
+            height={height}
+          />
+        )}
+        onProgressChange={(_, absoluteProgress) =>
+          setFocusedIndex(Math.round(absoluteProgress))
+        }
+      />
+      <Center>
+        <HStack space={1.5}>
+          {data.map((index) => (
+            <Box
+              key={index}
+              bg={index === focusedIndex ? accentColor : primaryColor}
+              w={2}
+              h={2}
+              rounded="full"
+            />
+          ))}
+        </HStack>
+      </Center>
+    </VStack>
+  );
+};
+
+export default ImageCarousel;

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -56,7 +56,7 @@ const Post = ({ post }: Props) => {
 
   return (
     <VStack w="full" alignItems="start" bg={baseBgColor}>
-      <Box p={2}>
+      <Box pl={2}>
         <UserTag user={author} />
       </Box>
       <Skeleton.Text p={2} lines={2} isLoaded={isTextContentLoaded}>

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -3,11 +3,22 @@ import { useEffect, useState } from 'react';
 import { Post as PostObj } from '../../xplat/types/post';
 import { User } from '../../xplat/types/user';
 import UserTag from '../profile/UserTag';
+import ImageCarousel from './ImageCarousel';
 
+/**
+ * A Post is a modular component that displays all relevant information about a user's post
+ *
+ * Posts can have the following information
+ *  1. Text content
+ *  2. Image content (multiple images)
+ *  3. Video content
+ *
+ * Text content is required, and is also the minimum required content loaded
+ * in order to render the actual post rather than its skeleton
+ */
 type Props = {
   post: PostObj | undefined;
 };
-
 const Post = ({ post }: Props) => {
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
 
@@ -33,7 +44,7 @@ const Post = ({ post }: Props) => {
       post.getAuthor().then(setAuthor);
       post.hasImageContent().then((hasImageContent) => {
         if (!hasImageContent) return;
-        post.getImageContentUrl().then((url) => setImageUrls([url!]));
+        post.getImageContentUrl().then((url) => setImageUrls([url!, url!]));
       });
       post.getTextContent().then(setTextContent);
     };
@@ -44,13 +55,28 @@ const Post = ({ post }: Props) => {
   const isTextContentLoaded = textContent !== '';
 
   return (
-    <VStack w="full" alignItems="start" bg={baseBgColor} p={2}>
-      <UserTag user={author} />
-      <Box w="full" px={4} pt={2}>
-        <Skeleton.Text lines={2} isLoaded={isTextContentLoaded}>
-          <Text>{textContent}</Text>
-        </Skeleton.Text>
+    <VStack w="full" alignItems="start" bg={baseBgColor}>
+      <Box p={2}>
+        <UserTag user={author} />
       </Box>
+      <Skeleton.Text p={2} lines={2} isLoaded={isTextContentLoaded}>
+        <Box p={2}>
+          <Text>{textContent}</Text>
+        </Box>
+      </Skeleton.Text>
+      <VStack
+        justifyContent="start"
+        alignItems="start"
+        w="full"
+        space={2}
+        pt={2}
+      >
+        <Skeleton w="full" h={40} isLoaded={isTextContentLoaded}>
+          {imageUrls !== undefined ? (
+            <ImageCarousel imageUrls={imageUrls} />
+          ) : null}
+        </Skeleton>
+      </VStack>
     </VStack>
   );
 };

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -1,0 +1,58 @@
+import { Box, Skeleton, Text, useColorModeValue, VStack } from 'native-base';
+import { useEffect, useState } from 'react';
+import { Post as PostObj } from '../../xplat/types/post';
+import { User } from '../../xplat/types/user';
+import UserTag from '../profile/UserTag';
+
+type Props = {
+  post: PostObj | undefined;
+};
+
+const Post = ({ post }: Props) => {
+  const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
+
+  // Author
+  const [author, setAuthor] = useState<User | undefined>(undefined);
+
+  // Video content
+
+  // Image content
+  const [imageUrls, setImageUrls] = useState<Array<string> | undefined>(
+    undefined
+  );
+
+  // Text content
+  const [textContent, setTextContent] = useState<string>('');
+
+  useEffect(() => {
+    const getData = async () => {
+      if (post === undefined) return;
+
+      await post.getData();
+
+      post.getAuthor().then(setAuthor);
+      post.hasImageContent().then((hasImageContent) => {
+        if (!hasImageContent) return;
+        post.getImageContentUrl().then((url) => setImageUrls([url!]));
+      });
+      post.getTextContent().then(setTextContent);
+    };
+
+    getData();
+  }, [post]);
+
+  const isTextContentLoaded = textContent !== '';
+
+  return (
+    <VStack w="full" alignItems="start" bg={baseBgColor} p={2}>
+      <UserTag user={author} />
+      <Box w="full" px={4} pt={2}>
+        <Skeleton.Text lines={2} isLoaded={isTextContentLoaded}>
+          <Text>{textContent}</Text>
+        </Skeleton.Text>
+      </Box>
+    </VStack>
+  );
+};
+
+export default Post;

--- a/components/profile/UserTag.tsx
+++ b/components/profile/UserTag.tsx
@@ -68,7 +68,7 @@ const UserTag = ({ user, size = 'sm' }: Props) => {
         return (
           <Box rounded="full" bg={baseBgColor}>
             <Tintable tinted={isHovered || isPressed} rounded />
-            <HStack alignItems="center" p={1} pr={3}>
+            <HStack alignItems="center" pr={3}>
               <Skeleton
                 w={sizedStyles[size].avatarSize}
                 h={sizedStyles[size].avatarSize}

--- a/components/profile/UserTag.tsx
+++ b/components/profile/UserTag.tsx
@@ -68,7 +68,7 @@ const UserTag = ({ user, size = 'sm' }: Props) => {
         return (
           <Box rounded="full" bg={baseBgColor}>
             <Tintable tinted={isHovered || isPressed} rounded />
-            <HStack alignItems="center" py={1.5} px={2}>
+            <HStack alignItems="center" p={1} pr={3}>
               <Skeleton
                 w={sizedStyles[size].avatarSize}
                 h={sizedStyles[size].avatarSize}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.6",
     "react-native-paper": "^4.12.5",
+    "react-native-reanimated": "~2.9.1",
+    "react-native-reanimated-carousel": "^3.1.5",
     "react-native-safe-area-context": "4.3.1",
     "react-native-screens": "~3.15.0",
     "react-native-svg": "12.3.0",

--- a/screens/sandbox/PostWrapper.tsx
+++ b/screens/sandbox/PostWrapper.tsx
@@ -1,12 +1,25 @@
-import { Center } from 'native-base';
+import { Divider, ScrollView, useColorModeValue, VStack } from 'native-base';
 import Post from '../../components/media/Post';
-import { postMock } from '../../utils/mocks';
+import { postMock, postMockNoImage } from '../../utils/mocks';
+
+const padifyPost = (post: JSX.Element) => {
+  return (
+    <VStack>
+      <Divider my={4} />
+      {post}
+    </VStack>
+  );
+};
 
 const PostWrapper = () => {
+  const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
+
   return (
-    <Center>
+    <ScrollView w="full" bg={baseBgColor}>
       <Post post={postMock} />
-    </Center>
+      {padifyPost(<Post post={postMockNoImage} />)}
+      {padifyPost(<Post post={undefined} />)}
+    </ScrollView>
   );
 };
 

--- a/screens/sandbox/PostWrapper.tsx
+++ b/screens/sandbox/PostWrapper.tsx
@@ -5,7 +5,7 @@ import { postMock } from '../../utils/mocks';
 const PostWrapper = () => {
   return (
     <Center>
-      <Post post={postMock} />
+      <Post post={undefined} />
     </Center>
   );
 };

--- a/screens/sandbox/PostWrapper.tsx
+++ b/screens/sandbox/PostWrapper.tsx
@@ -1,0 +1,13 @@
+import { Center } from 'native-base';
+import Post from '../../components/media/Post';
+import { postMock } from '../../utils/mocks';
+
+const PostWrapper = () => {
+  return (
+    <Center>
+      <Post post={postMock} />
+    </Center>
+  );
+};
+
+export default PostWrapper;

--- a/screens/sandbox/PostWrapper.tsx
+++ b/screens/sandbox/PostWrapper.tsx
@@ -5,7 +5,7 @@ import { postMock } from '../../utils/mocks';
 const PostWrapper = () => {
   return (
     <Center>
-      <Post post={undefined} />
+      <Post post={postMock} />
     </Center>
   );
 };

--- a/screens/sandbox/PostWrapper.tsx
+++ b/screens/sandbox/PostWrapper.tsx
@@ -16,9 +16,11 @@ const PostWrapper = () => {
 
   return (
     <ScrollView w="full" bg={baseBgColor}>
+      <Divider mb={4} />
       <Post post={postMock} />
       {padifyPost(<Post post={postMockNoImage} />)}
       {padifyPost(<Post post={undefined} />)}
+      <Divider mt={4} />
     </ScrollView>
   );
 };

--- a/utils/mocks.tsx
+++ b/utils/mocks.tsx
@@ -47,7 +47,8 @@ export const userMock = new UserMock(
 export const postMock = new PostMock(
   userMock,
   new Date(Date.now()),
-  'This is really the best post ever. Like, wow! I like rocks :p',
+  'This is really the best post ever. Like, wow! I like rocks. Who would have thought that rocks would be so cool. Also grabbing them.',
+  profilePic,
   [],
   []
 );

--- a/utils/mocks.tsx
+++ b/utils/mocks.tsx
@@ -48,7 +48,14 @@ export const postMock = new PostMock(
   userMock,
   new Date(Date.now()),
   'This is really the best post ever. Like, wow! I like rocks. Who would have thought that rocks would be so cool. Also grabbing them.',
-  profilePic,
+  [],
+  [],
+  profilePic
+);
+export const postMockNoImage = new PostMock(
+  userMock,
+  new Date(Date.now()),
+  'This is really the best post ever. Like, wow! I like rocks. Who would have thought that rocks would be so cool. Also grabbing them.',
   [],
   []
 );

--- a/utils/mocks.tsx
+++ b/utils/mocks.tsx
@@ -1,5 +1,6 @@
 import { LazyStaticImage } from '../xplat/types/common';
 import { ForumMock } from '../xplat/types/forum';
+import { PostMock } from '../xplat/types/post';
 import { RouteMock } from '../xplat/types/route';
 import { TagMock } from '../xplat/types/tag';
 import { UserStatus } from '../xplat/types/types';
@@ -42,4 +43,11 @@ export const userMock = new UserMock(
   [],
   [],
   profilePic
+);
+export const postMock = new PostMock(
+  userMock,
+  new Date(Date.now()),
+  'This is really the best post ever. Like, wow! I like rocks :p',
+  [],
+  []
 );

--- a/utils/routes/sandbox/names.ts
+++ b/utils/routes/sandbox/names.ts
@@ -10,5 +10,6 @@ export const names = [
   'UserRow',
   'LeaderboardRanking',
   'UserTag',
+  'Post',
 ] as const;
 export type Name = typeof names[number];

--- a/utils/routes/sandbox/paramList.ts
+++ b/utils/routes/sandbox/paramList.ts
@@ -9,4 +9,5 @@ export type ParamList = {
   UserRow: undefined;
   LeaderboardRanking: undefined;
   UserTag: undefined;
+  Post: undefined;
 };

--- a/utils/routes/sandbox/routes.ts
+++ b/utils/routes/sandbox/routes.ts
@@ -10,6 +10,7 @@ import LeaderboardCardWrapper from '../../../screens/sandbox/LeaderboardCardWrap
 import UserRowWrapper from '../../../screens/sandbox/UserRowWrapper';
 import LeaderboardRankingWrapper from '../../../screens/sandbox/LeaderboardRankingWrapper';
 import UserTagWrapper from '../../../screens/sandbox/UserTagWrapper';
+import PostWrapper from '../../../screens/sandbox/PostWrapper';
 
 export type Route = {
   name: Name;
@@ -56,5 +57,9 @@ export const routes: Array<Route> = [
   {
     name: 'UserTag',
     component: UserTagWrapper,
+  },
+  {
+    name: 'Post',
+    component: PostWrapper,
   },
 ];

--- a/utils/style.tsx
+++ b/utils/style.tsx
@@ -1,28 +1,3 @@
 export const LAYERS = {
   TINT: 9999,
 };
-
-export const toHex = (color: number) => {
-  const x = color.toString(16);
-  return x.length === 1 ? '0' + x : x;
-};
-export const gradientPicker = (
-  color1: string,
-  color2: string,
-  ratio: number
-) => {
-  const r = Math.ceil(
-    parseInt(color1.substring(0, 2), 16) * ratio +
-      parseInt(color2.substring(0, 2), 16) * (1 - ratio)
-  );
-  const g = Math.ceil(
-    parseInt(color1.substring(2, 4), 16) * ratio +
-      parseInt(color2.substring(2, 4), 16) * (1 - ratio)
-  );
-  const b = Math.ceil(
-    parseInt(color1.substring(4, 6), 16) * ratio +
-      parseInt(color2.substring(4, 6), 16) * (1 - ratio)
-  );
-
-  return toHex(r) + toHex(g) + toHex(b);
-};

--- a/utils/style.tsx
+++ b/utils/style.tsx
@@ -1,3 +1,28 @@
 export const LAYERS = {
   TINT: 9999,
 };
+
+export const toHex = (color: number) => {
+  const x = color.toString(16);
+  return x.length === 1 ? '0' + x : x;
+};
+export const gradientPicker = (
+  color1: string,
+  color2: string,
+  ratio: number
+) => {
+  const r = Math.ceil(
+    parseInt(color1.substring(0, 2), 16) * ratio +
+      parseInt(color2.substring(0, 2), 16) * (1 - ratio)
+  );
+  const g = Math.ceil(
+    parseInt(color1.substring(2, 4), 16) * ratio +
+      parseInt(color2.substring(2, 4), 16) * (1 - ratio)
+  );
+  const b = Math.ceil(
+    parseInt(color1.substring(4, 6), 16) * ratio +
+      parseInt(color2.substring(4, 6), 16) * (1 - ratio)
+  );
+
+  return toHex(r) + toHex(g) + toHex(b);
+};


### PR DESCRIPTION
## Describe your changes
In this PR, we introduce the `Post` component, with basic support for both text and image content. To make it happen, I had to build the `ImageCarousel` component to support multiple images in a sliding window.

It should be noted that for now the backend does not support multiple images, so the front end currently registers the image content twice in order to properly test the `Post`. This will be changed once posts support multiple images.

|Text and Image|Text Only|Loading|
|-|-|-|
|<img width="375" alt="Screenshot 2022-12-22 at 1 04 52 AM" src="https://user-images.githubusercontent.com/36250052/209068032-6fc048df-6c96-4723-9eb9-e4e4c4697949.png">|<img width="373" alt="Screenshot 2022-12-22 at 1 05 29 AM" src="https://user-images.githubusercontent.com/36250052/209068108-c31fb7de-f0e2-41e4-9d63-acdea5fea0e7.png">|<img width="373" alt="Screenshot 2022-12-22 at 1 10 05 AM" src="https://user-images.githubusercontent.com/36250052/209068729-75dd467a-034d-4b9b-aa14-35aa44a80853.png">|

## Issue ticket number and link
#13

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
