### PR TITLE
Header menu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ export default function App() {
               name={route.name}
               component={route.component}
               key={route.name}
+              options={{ headerShown: route.name === 'Tabs' ? false : true }}
             />
           ))}
         </RootStack.Navigator>

--- a/components/header/HeaderMenu.tsx
+++ b/components/header/HeaderMenu.tsx
@@ -1,0 +1,39 @@
+import { HStack, Icon, Menu, Pressable } from 'native-base';
+import { Entypo } from '@expo/vector-icons';
+
+type Props = {
+  navigate: Function;
+};
+
+const PressableIcon = (triggerProps: any) => {
+  return (
+    <Pressable {...triggerProps}>
+      <Icon
+        as={<Entypo name="dots-three-horizontal" />}
+        color="black"
+        size="lg"
+      />
+    </Pressable>
+  );
+};
+
+const HeaderMenu = ({ navigate }: Props) => {
+  return (
+    <HStack space={3}>
+      <Menu
+        trigger={(triggerProps) => {
+          return PressableIcon(triggerProps);
+        }}
+      >
+        <Menu.Item onPress={() => navigate('Settings')}>Settings</Menu.Item>
+        <Menu.Item onPress={() => navigate('Tutorial')}>Tutorial</Menu.Item>
+        <Menu.Item onPress={() => navigate('LostAndFound')}>
+          Lost and Found
+        </Menu.Item>
+        <Menu.Item>Logout</Menu.Item>
+      </Menu>
+    </HStack>
+  );
+};
+
+export default HeaderMenu;

--- a/utils/routes/tabs/routes.tsx
+++ b/utils/routes/tabs/routes.tsx
@@ -15,6 +15,7 @@ import { tabNameToRouteData } from '../routes';
 import { ParamList as SandboxParamList } from '../sandbox/paramList';
 import { ParamList as SearchParamList } from '../search/paramList';
 import { Name, Name as TabName } from './names';
+import HeaderMenu from '../../../components/header/HeaderMenu';
 
 export type Route = {
   name: Name;
@@ -23,13 +24,22 @@ export type Route = {
   stack: any;
 };
 
+const headerRightButton = (navigation: any) => {
+  return <HeaderMenu navigate={navigation.navigate} />;
+};
+
 // Builds a navigator stack for a given tab
 const buildStack = (tabName: TabName, stack: any) => {
   const routeData = tabNameToRouteData[tabName];
   const Stack = stack;
   return () => {
     return (
-      <Stack.Navigator initialRouteName={routeData.initialRouteName}>
+      <Stack.Navigator
+        initialRouteName={routeData.initialRouteName}
+        screenOptions={({ navigation }: { navigation: any }) => ({
+          headerRight: () => headerRightButton(navigation),
+        })}
+      >
         {routeData.routes.map((route) => (
           <Stack.Screen
             name={route.name}


### PR DESCRIPTION
Note: This branch is merging into the tripleNestedNavigation branch.

## Describe your changes
Creates the HeaderMenu for the App's bar. Pressing the buttons will navigate you to the specific screen, except for the logout button, that currently doesn't do anything.

![Screenshot_20230111-124102_Expo Go](https://user-images.githubusercontent.com/5271307/211879193-9d02c066-a243-4058-b359-53919a91c33a.jpg)

![Screenshot_20230111-124107_Expo Go](https://user-images.githubusercontent.com/5271307/211879201-dd59efa6-7bec-4832-aec4-d5f1c63151b8.jpg)

![1673458875559](https://user-images.githubusercontent.com/5271307/211879295-1513cbb3-4a3b-4d54-9a4e-5965f1c9b0b7.jpg)


## Issue ticket number and link
#38 

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
