### PR TITLE
Android Compat -- alignItems + Gesture handler

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,9 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
 import { extendTheme, NativeBaseProvider } from 'native-base';
+import { StyleSheet } from 'react-native';
 import 'react-native-gesture-handler';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ParamList as RootStackParamList } from './utils/routes/root/paramList';
 import { routes as rootStackRoutes } from './utils/routes/root/routes';
 
@@ -26,20 +28,28 @@ const RootStack = createNativeStackNavigator<RootStackParamList>();
 // Construct tabs and their subtrees
 export default function App() {
   return (
-    <NativeBaseProvider theme={theme}>
-      <StatusBar style="auto" />
-      <NavigationContainer>
-        <RootStack.Navigator initialRouteName="Tabs">
-          {rootStackRoutes.map((route) => (
-            <RootStack.Screen
-              name={route.name}
-              component={route.component}
-              key={route.name}
-              options={{ headerShown: route.name === 'Tabs' ? false : true }}
-            />
-          ))}
-        </RootStack.Navigator>
-      </NavigationContainer>
-    </NativeBaseProvider>
+    <GestureHandlerRootView style={styles.gestureHandler}>
+      <NativeBaseProvider theme={theme}>
+        <StatusBar style="auto" />
+        <NavigationContainer>
+          <RootStack.Navigator initialRouteName="Tabs">
+            {rootStackRoutes.map((route) => (
+              <RootStack.Screen
+                name={route.name}
+                component={route.component}
+                key={route.name}
+                options={{ headerShown: route.name === 'Tabs' ? false : true }}
+              />
+            ))}
+          </RootStack.Navigator>
+        </NavigationContainer>
+      </NativeBaseProvider>
+    </GestureHandlerRootView>
   );
 }
+
+const styles = StyleSheet.create({
+  gestureHandler: {
+    flex: 1,
+  },
+});

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -58,7 +58,7 @@ const Post = ({ post }: Props) => {
   const isMediaLoaded = mediaList !== undefined;
 
   return (
-    <VStack w="full" alignItems="start" bg={baseBgColor}>
+    <VStack w="full" alignItems="flex-start" bg={baseBgColor}>
       <Box pl={2}>
         <UserTag user={author} />
       </Box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "18.0.0",
         "react-dom": "18.0.0",
         "react-native": "0.69.6",
+        "react-native-gesture-handler": "~2.5.0",
         "react-native-paper": "^4.12.5",
         "react-native-reanimated": "~2.9.1",
         "react-native-reanimated-carousel": "^3.1.5",
@@ -1865,7 +1866,6 @@
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "peer": true,
       "dependencies": {
         "@types/hammerjs": "^2.0.36"
       },
@@ -6052,8 +6052,7 @@
     "node_modules/@types/hammerjs": {
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
-      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
-      "peer": true
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "node_modules/@types/invariant": {
       "version": "2.2.35",
@@ -14438,10 +14437,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
-      "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
-      "peer": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.5.0.tgz",
+      "integrity": "sha512-djZdcprFf08PZC332D+AeG5wcGeAPhzfCJtB3otUgOgTlvjVXmg/SLFdPJSpzLBqkRAmrC77tM79QgKbuLxkfw==",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-native-svg": "12.3.0",
     "react-native-vector-icons": "^9.2.0",
     "react-native-web": "~0.18.7",
-    "expo-av": "~12.0.4"
+    "expo-av": "~12.0.4",
+    "react-native-gesture-handler": "~2.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
## Describe your changes
Looks like our application has some issues on Android. Specifically the following:
1. `alignItems="start"` does not work on Android. Must be replaced by `alignItems="flex-start"`
2. The entire application must be wrapped in a gesture handler.

## Issue ticket number and link
#53 

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
