### PR TITLE
Update userPermissionLevel in atom on Auth

### DIFF
--- a/components/util/AuthProvider.tsx
+++ b/components/util/AuthProvider.tsx
@@ -4,7 +4,9 @@ import {
   isEmailVerifiedAtom,
   isInitializingAtom,
   isSignedInAtom,
+  userPermissionLevelAtom,
 } from '../../utils/atoms';
+import { getCurrentUser } from '../../xplat/api';
 import { auth } from '../../xplat/Firebase';
 
 type Props = {
@@ -14,20 +16,30 @@ const AuthProvider = ({ children }: Props) => {
   const setIsInitializing = useSetRecoilState(isInitializingAtom);
   const setIsSignedIn = useSetRecoilState(isSignedInAtom);
   const setIsEmailVerified = useSetRecoilState(isEmailVerifiedAtom);
+  const setUserPermissionLevel = useSetRecoilState(userPermissionLevelAtom);
 
   useEffect(
     () =>
-      auth.onAuthStateChanged((user) => {
+      auth.onAuthStateChanged(async (user) => {
         if (user !== null) {
           setIsSignedIn(true);
           setIsEmailVerified(user.emailVerified);
+
+          const lazyUser = await getCurrentUser();
+          setUserPermissionLevel(await lazyUser.getStatus());
         } else {
           setIsSignedIn(false);
           setIsEmailVerified(false);
+          setUserPermissionLevel(undefined);
         }
         setIsInitializing(false);
       }),
-    [setIsEmailVerified, setIsInitializing, setIsSignedIn]
+    [
+      setIsEmailVerified,
+      setIsInitializing,
+      setIsSignedIn,
+      setUserPermissionLevel,
+    ]
   );
 
   return <>{children}</>;

--- a/utils/atoms.ts
+++ b/utils/atoms.ts
@@ -1,11 +1,12 @@
 import { atom } from 'recoil';
+import { UserStatus } from '../xplat/types/common';
 
-export const isInitializingAtom = atom({
+export const isInitializingAtom = atom<boolean>({
   key: 'isInitializing',
   default: true,
 });
 
-export const isSignedInAtom = atom({
+export const isSignedInAtom = atom<boolean>({
   key: 'isSignedIn',
   default: false,
 });
@@ -16,7 +17,12 @@ export const isSignedInAtom = atom({
  * time that they open the application. Users that should be blocked
  * will be before they have time to do anything meaningful.
  **/
-export const isEmailVerifiedAtom = atom({
+export const isEmailVerifiedAtom = atom<boolean>({
   key: 'isEmailVerified',
   default: true,
+});
+
+export const userPermissionLevelAtom = atom<UserStatus | undefined>({
+  key: 'userPermissionLevel',
+  default: undefined,
 });


### PR DESCRIPTION
## Describe your changes
Move the userPerm status into an Atom on Auth status update. Tested with logs.

While testing, noticed that xplat doesn't seem to be updating the status automagically. Is this something we need to do from client @JakeSteinebronn @Henry-Graves ?

## Issue ticket number and link
#81
#80 

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
