### PR TITLE
Fix state bug and use user atom

### DIFF
--- a/components/misc/IconToggle.tsx
+++ b/components/misc/IconToggle.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 
 type Props = {
@@ -9,6 +9,10 @@ type Props = {
 };
 const IconToggle = ({ status, onToggle, onIcon, offIcon }: Props) => {
   const [statusLocal, setStatusLocal] = useState<boolean>(status);
+
+  useEffect(() => {
+    setStatusLocal(status);
+  }, [status]);
 
   const toggle = async () => {
     setStatusLocal(!statusLocal);

--- a/components/misc/LikeButton.tsx
+++ b/components/misc/LikeButton.tsx
@@ -1,5 +1,5 @@
 import { Flex, Icon, Text } from 'native-base';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import IconToggle from './IconToggle';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -11,6 +11,11 @@ type Props = {
 const LikeButton = ({ isLiked, onToggleLike, numLikes }: Props) => {
   const [isLikedLocal, setIsLikedLocal] = useState<boolean>(isLiked);
   const [numLikesLocal, setNumLikesLocal] = useState<number>(numLikes);
+
+  useEffect(() => {
+    setIsLikedLocal(isLiked);
+    setNumLikesLocal(numLikes);
+  }, [isLiked, numLikes]);
 
   const toggleIsLikedLocal = () => {
     setIsLikedLocal(!isLikedLocal);

--- a/components/route/RouteView.tsx
+++ b/components/route/RouteView.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from 'react';
 import { ImageBackground, StyleSheet } from 'react-native';
 import StarRating from 'react-native-star-rating-widget';
 import { useRecoilState } from 'recoil';
-import { focusedRouteAtom } from '../../utils/atoms';
+import { focusedRouteAtom, userAtom } from '../../utils/atoms';
 import { getCurrentUser } from '../../xplat/api';
 import { RouteStatus } from '../../xplat/types/route';
 import { User } from '../../xplat/types/user';
@@ -28,6 +28,7 @@ const FORCED_THUMBNAIL_HEIGHT = 200;
 
 const RouteView = () => {
   const [route] = useRecoilState(focusedRouteAtom);
+  const [user] = useRecoilState(userAtom);
 
   // Guaranteed to exist
   const [name, setName] = useState<string>('');
@@ -57,12 +58,12 @@ const RouteView = () => {
   const [isSending, setIsSending] = useState<boolean>(false);
 
   const onToggleIsLiked = async () => {
-    if (route === undefined) return;
+    if (route === undefined || user === null) return;
     setIsLiked(!isLiked);
     if (!isLiked) {
-      route.addLike(await getCurrentUser());
+      route.addLike(user);
     } else {
-      route.removeLike(await getCurrentUser());
+      route.removeLike(user);
     }
   };
 
@@ -115,11 +116,13 @@ const RouteView = () => {
         if (hasRope) route.getRope().then(setRope);
       });
 
-      route.likedBy(await getCurrentUser()).then(setIsLiked);
+      if (user !== null) {
+        route.likedBy(user).then(setIsLiked);
+      }
     };
 
     fetchData();
-  }, [route]);
+  }, [route, user]);
 
   return (
     <>


### PR DESCRIPTION
# Changes
We had a bug, where I was default initializing state to values passed in from props. This PR fixes this issue, and converts recent usage of `await getCurrentUser()` to your new global User atom.

# Issue ticket number and link
Hotfix