### PR TITLE
Support small size user tag and use in RouteView

### DIFF
--- a/components/profile/UserTag.tsx
+++ b/components/profile/UserTag.tsx
@@ -15,9 +15,15 @@ import Tintable from '../util/Tintable';
 // TODO
 const navigateToProfile = () => { };
 
-type Size = 'sm' | 'lg';
+type Size = 'sm' | 'md' | 'lg';
 const sizedStyles = {
   sm: {
+    avatarSize: 8,
+    preloadTextWidth: 18,
+    displayNameSize: 'sm',
+    usernameSize: 'xs',
+  },
+  md: {
     avatarSize: 12,
     preloadTextWidth: 24,
     displayNameSize: 'md',
@@ -35,7 +41,7 @@ type Props = {
   user: User | undefined;
   size?: Size;
 };
-const UserTag = ({ user, size = 'sm' }: Props) => {
+const UserTag = ({ user, size = 'md' }: Props) => {
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
 
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);

--- a/components/route/RouteView.tsx
+++ b/components/route/RouteView.tsx
@@ -161,7 +161,7 @@ const RouteView = () => {
                   <Text fontSize="lg" color="grey" fontWeight="bold" mb={2}>
                     Setter
                   </Text>
-                  <UserTag user={setter} />
+                  <UserTag user={setter} size="sm" />
                 </VStack>
               ) : null}
               <VStack


### PR DESCRIPTION
# Changes
Adds support for a smaller sized `UserTag` component, and uses it in the `RouteView` component. This was necessary because some usernames are long enough to wrap the flexbox.

<img width="369" alt="Screenshot 2023-01-24 at 12 34 47 AM" src="https://user-images.githubusercontent.com/36250052/214219475-bc1a9e33-4672-4c8f-9ba2-40f49c5adcc1.png">

# Issue ticket number and link
#83 