### PR TITLE
Edit profile Skeleton

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,6 +28,14 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "The app accesses your photos to let you share them with your friends."
+        }
+      ]
+    ]
   }
 }

--- a/components/profile/ChangeEmail.tsx
+++ b/components/profile/ChangeEmail.tsx
@@ -1,0 +1,7 @@
+import { Text } from 'native-base';
+
+const ChangeEmail = () => {
+  return <Text>Trying to change email</Text>;
+};
+
+export default ChangeEmail;

--- a/components/profile/ChangePassword.tsx
+++ b/components/profile/ChangePassword.tsx
@@ -1,0 +1,20 @@
+import { Center, FormControl, Input, VStack } from 'native-base';
+
+const ChangePassword = () => {
+  return (
+    <Center width="full" p="3">
+      <VStack width="full">
+        <FormControl>
+          <FormControl.Label>Old Password</FormControl.Label>
+          <Input />
+        </FormControl>
+        <FormControl mt="3">
+          <FormControl.Label>New Password</FormControl.Label>
+          <Input />
+        </FormControl>
+      </VStack>
+    </Center>
+  );
+};
+
+export default ChangePassword;

--- a/components/profile/EditProfileModal.tsx
+++ b/components/profile/EditProfileModal.tsx
@@ -1,0 +1,148 @@
+import {
+  FormControl,
+  Input,
+  Modal,
+  Button,
+  Center,
+  HStack,
+  useColorModeValue,
+  Box,
+} from 'native-base';
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { userAtom } from '../../utils/atoms';
+import ChangeEmail from './ChangeEmail';
+import ChangePassword from './ChangePassword';
+import UploadImage from './UploadImage';
+
+export type AvatarUrlData = {
+  oldAvatarUrl: string;
+  newAvatarUrl: string;
+};
+
+type Props = {
+  isOpen: any;
+  onClose: any;
+};
+
+/**
+ * Modal that allow's the user to edit their profile.
+ */
+function EditProfileModal({ isOpen, onClose }: Props) {
+  const [avatarUrlData, setAvatarUrlData] = useState<AvatarUrlData>({
+    oldAvatarUrl: '',
+    newAvatarUrl: '',
+  });
+  const [signedInUser, setSignedInUser] = useRecoilState(userAtom);
+  const [viewChangePassword, setViewChangePassword] = useState<boolean>(false);
+  const [viewChangeEmail, setViewChangeEmail] = useState<boolean>(false);
+
+  const secondaryBgColor = useColorModeValue(
+    'lightMode.secondary',
+    'darkMode.secondary'
+  );
+
+  useEffect(() => {
+    const getData = async () => {
+      const avatarUrl = await signedInUser?.getAvatarUrl();
+      if (avatarUrl) {
+        setAvatarUrlData({
+          oldAvatarUrl: avatarUrl,
+          newAvatarUrl: avatarUrl,
+        });
+      }
+    };
+    getData();
+  }, [signedInUser]);
+
+  const handleClose = () => {
+    setViewChangePassword(false);
+    setViewChangeEmail(false);
+    setAvatarUrlData({
+      oldAvatarUrl: avatarUrlData.oldAvatarUrl,
+      newAvatarUrl: avatarUrlData.oldAvatarUrl,
+    });
+    onClose();
+  };
+
+  const handleCancel = () => {
+    if (viewChangePassword) {
+      setViewChangePassword(false);
+    } else if (viewChangeEmail) {
+      setViewChangeEmail(false);
+    } else {
+      handleClose();
+    }
+  };
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={handleClose}>
+        <Modal.Content maxWidth="lg">
+          <Modal.CloseButton />
+          <Modal.Header>Edit Profile</Modal.Header>
+          <Modal.Body>
+            {viewChangePassword ? (
+              <ChangePassword />
+            ) : viewChangeEmail ? (
+              <ChangeEmail />
+            ) : (
+              <Box>
+                <Center>
+                  <UploadImage
+                    avatarUrlData={avatarUrlData}
+                    setAvatarUrlData={setAvatarUrlData}
+                  />
+                </Center>
+                <FormControl>
+                  <FormControl.Label>Name</FormControl.Label>
+                  <Input placeholder={signedInUser?.displayName} />
+                </FormControl>
+                <FormControl mt="3">
+                  <FormControl.Label>Bio</FormControl.Label>
+                  <Input placeholder={signedInUser?.bio} />
+                </FormControl>
+                <HStack pt="3" space="xs" justifyContent="space-between">
+                  <Button
+                    onPress={() => {
+                      setViewChangePassword(true);
+                    }}
+                    size="sm"
+                    bg={secondaryBgColor}
+                  >
+                    Change Password
+                  </Button>
+                  <Button
+                    onPress={() => {
+                      setViewChangeEmail(true);
+                    }}
+                    size="sm"
+                    bg={secondaryBgColor}
+                  >
+                    Change Email
+                  </Button>
+                </HStack>
+              </Box>
+            )}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button.Group space={2}>
+              <Button
+                variant="ghost"
+                colorScheme="blueGray"
+                onPress={handleCancel}
+              >
+                Cancel
+              </Button>
+              <Button bg={secondaryBgColor} onPress={handleClose}>
+                Save
+              </Button>
+            </Button.Group>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+}
+
+export default EditProfileModal;

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -21,6 +21,7 @@ import Feed from '../media/Feed';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from '../../utils/atoms';
 import { QueryCursor } from '../../xplat/types/queryCursors';
+import EditProfileModal from './EditProfileModal';
 
 /**
  * The profile component displays the profile banner, a statbox,
@@ -40,12 +41,12 @@ const Profile = ({ profileIsMine, userOfProfile, navigate }: Props) => {
   const [topRopeGrade, setTopRopeGrade] = useState<string>('');
   const [numOfSends, setNumOfSends] = useState<string>('');
   const signedInUser = useRecoilValue(userAtom);
+  const [showModal, setShowModal] = useState(false);
   // TODO: Update default to check if signedInUser is following userOfProfile
   const [isFollowing, setIsFollowing] = useState<boolean>(false);
   const [postsCursor, setPostsCursor] = useState<
     QueryCursor<PostObj> | undefined
   >(undefined);
-
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
   const secondaryBgColor = useColorModeValue(
     'lightMode.secondary',
@@ -59,7 +60,7 @@ const Profile = ({ profileIsMine, userOfProfile, navigate }: Props) => {
 
   const handleButtonPress = async () => {
     if (profileIsMine) {
-      //TODO: Edit Profile
+      setShowModal(true);
     } else if (isFollowing && signedInUser !== undefined) {
       await signedInUser.unfollowUser(userOfProfile);
       setIsFollowing(false);
@@ -71,8 +72,13 @@ const Profile = ({ profileIsMine, userOfProfile, navigate }: Props) => {
     }
   };
 
+  const onClose = () => {
+    setShowModal(false);
+  };
+
   const profileComponent = (
     <VStack space="xs" w="full" bg={baseBgColor}>
+      <EditProfileModal isOpen={showModal} onClose={onClose} />
       <Box>
         <Box p="5">
           <ProfileBanner user={userOfProfile} />
@@ -82,10 +88,10 @@ const Profile = ({ profileIsMine, userOfProfile, navigate }: Props) => {
             <Button
               variant="subtle"
               size="md"
-              bgColor={secondaryBgColor}
+              bg={secondaryBgColor}
               rounded="2xl"
               _text={{ color: 'black' }}
-              onPress={() => handleButtonPress}
+              onPress={handleButtonPress}
             >
               {profileIsMine
                 ? 'Edit Profile'

--- a/components/profile/UploadImage.tsx
+++ b/components/profile/UploadImage.tsx
@@ -1,0 +1,110 @@
+import {
+  Avatar,
+  Box,
+  Pressable,
+  Text,
+  VStack,
+  Alert,
+  Collapse,
+  HStack,
+  IconButton,
+  CloseIcon,
+  Center,
+} from 'native-base';
+import { useState } from 'react';
+import Tintable from '../util/Tintable';
+import * as ImagePicker from 'expo-image-picker';
+import { AvatarUrlData } from './EditProfileModal';
+
+/**
+ * Uses expo's Image Picker to choose an image from the device.
+ */
+type Props = {
+  avatarUrlData: AvatarUrlData;
+  setAvatarUrlData: any;
+};
+const UploadImage = ({ avatarUrlData, setAvatarUrlData }: Props) => {
+  const [showAlert, setShowAlert] = useState<boolean>(false);
+  const [status, requestPermission] = ImagePicker.useMediaLibraryPermissions();
+
+  const addImage = async () => {
+    if (!status?.granted) {
+      requestPermission().then((response) => {
+        if (!response.granted) setShowAlert(true);
+      });
+    } else {
+      const _image = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        aspect: [4, 3],
+        quality: 1,
+      });
+      if (!_image.cancelled) {
+        setAvatarUrlData({ ...avatarUrlData, newAvatarUrl: _image.uri });
+      }
+    }
+  };
+
+  return (
+    <Box>
+      <Collapse isOpen={showAlert}>
+        <Alert maxW="400" status="error">
+          <HStack
+            flexShrink={1}
+            space={2}
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <HStack flexShrink={1} space={2} alignItems="center">
+              <Alert.Icon />
+              <Text
+                fontSize="md"
+                fontWeight="medium"
+                _dark={{
+                  color: 'coolGray.800',
+                }}
+              >
+                Please grant camera roll permissions inside your system's
+                settings
+              </Text>
+            </HStack>
+            <IconButton
+              variant="unstyled"
+              _focus={{
+                borderWidth: 0,
+              }}
+              icon={<CloseIcon size="3" />}
+              _icon={{
+                color: 'coolGray.600',
+              }}
+              onPress={() => setShowAlert(false)}
+            />
+          </HStack>
+        </Alert>
+      </Collapse>
+      <Center>
+        <VStack pt="2">
+          <Pressable onPress={addImage}>
+            {({ isHovered, isPressed }) => {
+              return (
+                <Box>
+                  <Tintable tinted={isHovered || isPressed} rounded />
+                  <Avatar
+                    source={{ uri: avatarUrlData.newAvatarUrl }}
+                    bg="gray.300"
+                    size="2xl"
+                    mb={3}
+                  />
+                </Box>
+              );
+            }}
+          </Pressable>
+
+          <Text>Change profile picture</Text>
+        </VStack>
+      </Center>
+    </Box>
+  );
+};
+
+export default UploadImage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native-stack": "^6.9.0",
         "expo": "~46.0.9",
         "expo-av": "~12.0.4",
+        "expo-image-picker": "~13.3.1",
         "expo-linear-gradient": "~11.4.0",
         "expo-status-bar": "~1.4.0",
         "native-base": "^3.4.21",
@@ -9289,6 +9290,35 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-3.2.0.tgz",
+      "integrity": "sha512-LU3Q2prn64/HxdToDmxgMIRXS1ZvD9Q3iCxRVTZn1fPQNNDciIQFE5okaa74Ogx20DFHs90r6WoUd7w9Af1OGQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-13.3.1.tgz",
+      "integrity": "sha512-IY84uDu9uxetAup5yw0CIIujigl/lM3grwyfpeZFMKGmWHzmKamptjd/sG8K65xkb6tF9awmGMW0qglHQ9hakQ==",
+      "dependencies": {
+        "@expo/config-plugins": "~5.0.0",
+        "expo-image-loader": "~3.2.0",
+        "uuid": "7.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker/node_modules/uuid": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/native-stack": "^6.9.0",
     "expo": "~46.0.9",
     "expo-av": "~12.0.4",
+    "expo-image-picker": "~13.3.1",
     "expo-linear-gradient": "~11.4.0",
     "expo-status-bar": "~1.4.0",
     "native-base": "^3.4.21",


### PR DESCRIPTION
# Changes
Creates skeleton for allowing a user to edit their profile. Also creates component to allow a user to pick an image from their device.

https://user-images.githubusercontent.com/5271307/215290875-4436dcb2-c62c-4f8b-81b2-f8ee902c174a.mp4

Once the backend allows us to edit the profile then we will add the API functionality.

Note: On top of the avatar is a red line, this is a Collapse component that displays an alert saying that the user needs to give permission to the app to access their media if they didnt grant access. So for some reason the collapse component doesnt completely dissappear when it isn't expanded. Will fix this later.

# Issue ticket number and link
#109 #108