### PR TITLE
flexGrow 'unset' -> {0}

### DIFF
--- a/components/route/RouteView.tsx
+++ b/components/route/RouteView.tsx
@@ -162,7 +162,7 @@ const RouteView = () => {
           </Text>
           <HStack flexWrap="wrap" justifyContent="space-between" mx={4} mt={2}>
             {setter !== undefined ? (
-              <VStack justifyContent="flex-start" flexGrow="unset">
+              <VStack justifyContent="flex-start" flexGrow={0}>
                 <Text fontSize="lg" color="grey" fontWeight="bold" mb={2}>
                   Setter
                 </Text>
@@ -172,14 +172,14 @@ const RouteView = () => {
             <VStack
               justifyContent="flex-start"
               alignItems="flex-start"
-              flexGrow="unset"
+              flexGrow={0}
             >
               <Text fontSize="lg" color="grey" fontWeight="bold" mb={2}>
                 Rating
               </Text>
               <StarRating
                 rating={rating}
-                onChange={() => {}}
+                onChange={() => { }}
                 starStyle={styles.star}
                 animationConfig={{ scale: 1 }}
               />


### PR DESCRIPTION
# Changes
Apparently TypeScript lies. `flexGrow` cannot be a string, and I meant to use `0` here.

# Issue ticket number and link
#105 