### PR TITLE
Remove write-enabled entrypoints for non-authorized users

### DIFF
--- a/components/media/Comment.tsx
+++ b/components/media/Comment.tsx
@@ -1,7 +1,8 @@
 import { VStack, HStack, Text } from 'native-base';
 import { useQuery } from 'react-query';
 import { useRecoilValue } from 'recoil';
-import { userAtom } from '../../utils/atoms';
+import { userAtom, userPermissionLevelAtom } from '../../utils/atoms';
+import { permissionLevelCanWrite } from '../../utils/permissions';
 import { buildCommentFetcher } from '../../utils/queries';
 import { Comment as CommentObj } from '../../xplat/types';
 import LikeButton from '../misc/LikeButton';
@@ -16,6 +17,7 @@ type Props = {
 };
 const Comment = ({ comment }: Props) => {
   const user = useRecoilValue(userAtom);
+  const userPermissionLevel = useRecoilValue(userPermissionLevelAtom);
 
   const { isLoading, isError, data, error } = useQuery(
     comment.getId(),
@@ -40,7 +42,9 @@ const Comment = ({ comment }: Props) => {
     <VStack w="full" p={2} alignItems="flex-start">
       <HStack w="full" justifyContent="space-between">
         <UserTag user={data.author} size="sm" />
-        <LikeButton likes={data.likes} onSetIsLiked={onSetIsLiked} />
+        {permissionLevelCanWrite(userPermissionLevel) ? (
+          <LikeButton likes={data.likes} onSetIsLiked={onSetIsLiked} />
+        ) : null}
       </HStack>
       <Text my={2}>{data.textContent}</Text>
     </VStack>

--- a/screens/media/Comments.tsx
+++ b/screens/media/Comments.tsx
@@ -4,6 +4,7 @@ import {
   ScrollView,
   Spinner,
   useColorModeValue,
+  Text,
 } from 'native-base';
 import { useCallback, useEffect, useState } from 'react';
 import { NativeScrollEvent } from 'react-native';
@@ -12,7 +13,8 @@ import { useRecoilValue } from 'recoil';
 import { queryClient } from '../../App';
 import Comment from '../../components/media/Comment';
 import CommentTextInput from '../../components/media/CommentTextInput';
-import { userAtom } from '../../utils/atoms';
+import { userAtom, userPermissionLevelAtom } from '../../utils/atoms';
+import { permissionLevelCanWrite } from '../../utils/permissions';
 import { TabGlobalScreenProps } from '../../utils/types';
 import { constructPageData } from '../../xplat/queries';
 import { getIQParams_PostComments } from '../../xplat/queries/post';
@@ -36,6 +38,7 @@ const Comments = ({ route }: TabGlobalScreenProps<'Comments'>) => {
   const postDocRefId = route.params.postDocRefId;
 
   const user = useRecoilValue(userAtom);
+  const userPermissionLevel = useRecoilValue(userPermissionLevelAtom);
 
   const [isPostingComment, setIsPostingComment] = useState<boolean>(false);
   const [comments, setComments] = useState<CommentObj[]>([]);
@@ -105,10 +108,12 @@ const Comments = ({ route }: TabGlobalScreenProps<'Comments'>) => {
 
   return (
     <Box w="full" h="full" bg={baseBgColor}>
-      <CommentTextInput
-        onSubmitComment={postComment}
-        isLoading={isPostingComment}
-      />
+      {permissionLevelCanWrite(userPermissionLevel) ? (
+        <CommentTextInput
+          onSubmitComment={postComment}
+          isLoading={isPostingComment}
+        />
+      ) : null}
       <ScrollView
         onScroll={({ nativeEvent }) => {
           if (commentsQuery.hasNextPage && isCloseToBottom(nativeEvent)) {
@@ -117,11 +122,17 @@ const Comments = ({ route }: TabGlobalScreenProps<'Comments'>) => {
         }}
         scrollEventThrottle={1000}
       >
-        {comments.map((commentObj) => (
-          <Box key={commentObj.getId()}>
-            <Comment comment={commentObj} />
-          </Box>
-        ))}
+        {comments.length === 0 ? (
+          <Center mt={4}>
+            <Text color="gray.500">Nothing here yet...t!</Text>
+          </Center>
+        ) : (
+          comments.map((commentObj) => (
+            <Box key={commentObj.getId()}>
+              <Comment comment={commentObj} />
+            </Box>
+          ))
+        )}
         {commentsQuery.hasNextPage ? (
           <Center>
             <Spinner size="lg" />

--- a/screens/profile/Profile.tsx
+++ b/screens/profile/Profile.tsx
@@ -20,7 +20,8 @@ import LoadingProfile from '../../components/profile/LoadingProfile';
 import ProfileBanner from '../../components/profile/ProfileBanner';
 import StatBox from '../../components/profile/StatBox';
 import Tintable from '../../components/util/Tintable';
-import { userAtom } from '../../utils/atoms';
+import { userAtom, userPermissionLevelAtom } from '../../utils/atoms';
+import { permissionLevelCanWrite } from '../../utils/permissions';
 import { TabGlobalScreenProps } from '../../utils/types';
 import { User, containsRef } from '../../xplat/types';
 
@@ -33,6 +34,8 @@ import { User, containsRef } from '../../xplat/types';
  */
 const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
   const signedInUser = useRecoilValue(userAtom);
+  const userPermissionLevel = useRecoilValue(userPermissionLevelAtom);
+
   const profileIsMine = route.params?.userDocRefId === undefined;
   const userDocRefId = route.params?.userDocRefId ?? signedInUser?.docRef!.id;
 
@@ -111,20 +114,22 @@ const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
         </Box>
         <Center>
           <HStack space="md">
-            <Button
-              variant="subtle"
-              size="md"
-              bg={secondaryBgColor}
-              rounded="2xl"
-              _text={{ color: 'black' }}
-              onPress={handleButtonPress}
-            >
-              {profileIsMine
-                ? 'Edit Profile'
-                : isFollowing
-                ? 'Unfollow'
-                : 'Follow'}
-            </Button>
+            {permissionLevelCanWrite(userPermissionLevel) ? (
+              <Button
+                variant="subtle"
+                size="md"
+                bg={secondaryBgColor}
+                rounded="2xl"
+                _text={{ color: 'black' }}
+                onPress={handleButtonPress}
+              >
+                {profileIsMine
+                  ? 'Edit Profile'
+                  : isFollowing
+                  ? 'Unfollow'
+                  : 'Follow'}
+              </Button>
+            ) : null}
             <Center>
               <Pressable
                 onPress={async () => {

--- a/utils/permissions.tsx
+++ b/utils/permissions.tsx
@@ -1,0 +1,9 @@
+import { UserStatus } from '../xplat/types';
+
+export const permissionLevelCanWrite = (
+  permissionLevel: UserStatus | undefined
+) => {
+  return (
+    permissionLevel !== undefined && permissionLevel >= UserStatus.Approved
+  );
+};


### PR DESCRIPTION
# Changes
Gets rid of several buttons for users that aren't `approved` status or higher including:
1. Like buttons
2. Create Post buttons
3. Comment text inputs
4. Edit profile button

Also fixes a small visual bug in the `RouteView`

# Issue ticket number and link
#81 