### PR TITLE
Add timestamps to post and comment

### DIFF
--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -3,13 +3,13 @@ import { useNavigation } from '@react-navigation/native';
 import {
   Box,
   Button,
-  Center,
   HStack,
   Icon,
   Skeleton,
   Text,
   useColorModeValue,
   VStack,
+  Center,
 } from 'native-base';
 import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
@@ -18,6 +18,7 @@ import { FetchedPost, Post as PostObj } from '../../xplat/types';
 import UserTag, { UserTagSkeleton } from '../profile/UserTag';
 import { MediaType } from './Media';
 import MediaCarousel from './MediaCarousel';
+import Timestamp from './Timestamp';
 
 const PostSkeleton = () => {
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
@@ -120,7 +121,7 @@ const Post = ({ post }: Props) => {
   return (
     <VStack w="full" alignItems="flex-start" bg={baseBgColor}>
       <Box pl={2}>
-        <UserTag user={postData.author} />
+        <UserTag user={postData.author} timestamp={postData.timestamp} />
       </Box>
       <Box p={2}>
         <Text>{postData.textContent}</Text>

--- a/components/media/Timestamp.tsx
+++ b/components/media/Timestamp.tsx
@@ -1,0 +1,54 @@
+// The following is adapted from a now out-of-date timestamp formatter at
+// https://www.npmjs.com/package/react-timestamp/v/5.0.0?activeTab=readme
+// all credit goes to its author.
+
+import { useState, useEffect } from 'react';
+import {
+  toDate,
+  secondsBetweenDates,
+  YEAR,
+  distanceOfTimeInWords,
+  formatDate,
+  FormatOptions,
+} from '../../utils/react-timestamp-utils';
+import { Text } from 'native-base';
+
+type Props = {
+  date: Date | number | string;
+  relative?: boolean;
+  relativeTo?: Date | number | string;
+  options?: FormatOptions;
+  autoUpdate?: boolean;
+};
+
+export default function Timestamp({
+  date,
+  relative,
+  relativeTo,
+  options,
+  autoUpdate,
+}: Props) {
+  const [minutes, setMinutes] = useState<number>(0);
+  useEffect(() => {
+    if (!autoUpdate) return;
+
+    const interval = setInterval(() => setMinutes(minutes + 1), 60000);
+    return () => clearInterval(interval);
+  }, [autoUpdate, minutes]);
+
+  let possibleDate = toDate(date);
+  if (possibleDate === null) return null;
+
+  const relativeToDate: Date = toDate(relativeTo) || new Date();
+  const seconds = secondsBetweenDates(possibleDate, relativeToDate);
+  const isRelative = (relative && Math.abs(seconds) < YEAR) || relativeTo;
+  const text: string = isRelative
+    ? distanceOfTimeInWords(seconds, !relativeTo, options?.translate)
+    : formatDate(possibleDate, options);
+
+  return (
+    <Text fontSize="xs" color="grey">
+      {text}
+    </Text>
+  );
+}

--- a/components/profile/UserTag.tsx
+++ b/components/profile/UserTag.tsx
@@ -15,6 +15,7 @@ import { userAtom } from '../../utils/atoms';
 import { navigateToUserProfile } from '../../utils/nav';
 import { TabGlobalNavigationProp } from '../../utils/types';
 import { User } from '../../xplat/types/user';
+import Timestamp from '../media/Timestamp';
 import Tintable from '../util/Tintable';
 
 type Size = 'xs' | 'sm' | 'md' | 'lg';
@@ -73,8 +74,9 @@ type Props = {
   user: User;
   size?: Size;
   mini?: boolean;
+  timestamp?: Date;
 };
-const UserTag = ({ user, size = 'md', mini = false }: Props) => {
+const UserTag = ({ user, size = 'md', mini = false, timestamp }: Props) => {
   const navigation = useNavigation<TabGlobalNavigationProp>();
 
   const signedInUser = useRecoilValue(userAtom);
@@ -134,9 +136,16 @@ const UserTag = ({ user, size = 'md', mini = false }: Props) => {
                 >
                   {data.displayName}
                 </Text>
-                <Text fontSize={sizedStyles[size].usernameSize} color="grey">
-                  @{data.username}
-                </Text>
+                <HStack alignItems="center">
+                  <Text fontSize={sizedStyles[size].usernameSize} color="grey">
+                    @{data.username}
+                  </Text>
+                  {timestamp !== undefined ? (
+                    <Box ml={2}>
+                      <Timestamp relative date={timestamp} />
+                    </Box>
+                  ) : null}
+                </HStack>
               </VStack>
             </HStack>
           </Box>

--- a/components/profile/UserTag.tsx
+++ b/components/profile/UserTag.tsx
@@ -106,9 +106,16 @@ const UserTag = ({ user, size = 'md', mini = false, timestamp }: Props) => {
   if (mini) {
     return (
       <Pressable onPress={tryNavigate}>
-        <Text fontSize={sizedStyles[size].displayNameSize} fontWeight="bold">
-          {data.displayName}
-        </Text>
+        <HStack alignItems="center">
+          <Text fontSize={sizedStyles[size].displayNameSize} fontWeight="bold">
+            {data.displayName}
+          </Text>
+          {timestamp !== undefined ? (
+            <Box ml={2}>
+              <Timestamp relative date={timestamp} />
+            </Box>
+          ) : null}
+        </HStack>
       </Pressable>
     );
   }

--- a/utils/react-timestamp-utils.tsx
+++ b/utils/react-timestamp-utils.tsx
@@ -1,0 +1,215 @@
+// The following is ripped from a now out-of-date timestamp formatter at
+// https://www.npmjs.com/package/react-timestamp/v/5.0.0?activeTab=readme
+// all credit goes to its author.
+/* eslint-disable */
+
+export type FormatOptions = {
+  format?: string;
+  includeDay?: boolean;
+  twentyFourHour?: boolean;
+  translate?: (key: string) => string;
+};
+
+const defaultTranslate = (key: string, arg?: unknown): string => {
+  switch (key) {
+    case 'second':
+    case 'minute':
+    case 'hour':
+    case 'day':
+    case 'week':
+    case 'month':
+    case 'year':
+      return `${arg} ${key + (arg == 1 ? '' : 's')}`;
+
+    case 'd_ago':
+      return `${arg} ago`;
+
+    case 'in_d':
+      return `in ${arg}`;
+
+    default:
+      return key;
+  }
+};
+
+export const MINUTE = 60;
+export const HOUR = MINUTE * 60;
+export const DAY = 24 * HOUR;
+export const WEEK = DAY * 7;
+export const MONTH = (DAY * 365) / 12;
+export const YEAR = DAY * 365;
+
+/**
+ * Convert a string or number to a Date
+ * @param date Someting to convert to a Date
+ */
+export const toDate = (date?: Date | string | number): Date | null => {
+  if (!date) return new Date();
+
+  if (typeof date === 'number' || '' + parseInt(date as string, 10) == date) {
+    date = parseInt(date as string, 10);
+    if (isNaN(date)) return null;
+    date = new Date(date * 1000);
+  }
+
+  date = new Date(date);
+  if (isNaN(date.getTime())) return null;
+
+  const t: string[] = date.toJSON().split(/[:\-\+TZ\. ]/);
+  for (var i in t) {
+    if (t[i] !== '' && isNaN(parseInt(t[i], 10))) return null;
+  }
+
+  return date;
+};
+
+/**
+ * Format a date to a nice string
+ * @param date The date to format
+ * @param options Some extra options
+ */
+export const formatDate = (date: Date, options: FormatOptions = {}): string => {
+  options = {
+    format: 'full',
+    includeDay: false,
+    twentyFourHour: false,
+    ...options,
+  };
+
+  let hours: string;
+  let minutes: string;
+  let ampm: string;
+
+  // eg. 5 Nov 12, 1:37pm
+  if (options.twentyFourHour) {
+    hours = date.getHours().toString();
+    ampm = '';
+  } else {
+    if (date.getHours() % 12 == 0) {
+      hours = '12';
+    } else {
+      hours = (date.getHours() % 12).toString();
+    }
+
+    if (date.getHours() > 11) {
+      ampm = 'pm';
+    } else {
+      ampm = 'am';
+    }
+  }
+
+  if (date.getMinutes() < 10) {
+    minutes = '0' + date.getMinutes();
+  } else {
+    minutes = '' + date.getMinutes();
+  }
+
+  const t = options.translate || defaultTranslate;
+  const MONTHS = [
+    t('Jan'),
+    t('Feb'),
+    t('Mar'),
+    t('Apr'),
+    t('May'),
+    t('Jun'),
+    t('Jul'),
+    t('Aug'),
+    t('Sep'),
+    t('Oct'),
+    t('Nov'),
+    t('Dec'),
+  ];
+  const DAYS = [
+    t('Sunday'),
+    t('Monday'),
+    t('Tuesday'),
+    t('Wednesday'),
+    t('Thursday'),
+    t('Friday'),
+    t('Saturday'),
+  ];
+
+  var day = options.includeDay ? DAYS[date.getDay()] + ', ' : '';
+
+  switch (options.format) {
+    case 'date':
+      return `${day}${date.getDate()} ${
+        MONTHS[date.getMonth()]
+      } ${date.getFullYear()}`;
+
+    case 'time':
+      return `${hours}:${minutes}${ampm}`;
+
+    case 'json':
+      return date.toJSON();
+
+    case 'full':
+    default:
+      return `${day}${date.getDate()} ${
+        MONTHS[date.getMonth()]
+      } ${date.getFullYear()}, ${hours}:${minutes}${ampm}`;
+  }
+};
+
+/**
+ * Count the seconds between two dates
+ * @param date A date
+ * @param compareTo The other date
+ */
+export const secondsBetweenDates = (date: Date, compareTo: Date): number => {
+  return Math.floor((compareTo.getTime() - date.getTime()) / 1000);
+};
+
+/**
+ * Get a sentence fragment of the distance between two dates
+ * @param seconds The distance of time in seconds
+ * @param relativeToNow Are we comparing two dates or a date and now
+ */
+export const distanceOfTimeInWords = (
+  seconds: number,
+  relativeToNow: boolean = true,
+  translate: (key: string, arg?: unknown) => string = defaultTranslate
+): string => {
+  let isAgo: boolean = seconds >= 0;
+  const t = translate || defaultTranslate;
+
+  seconds = Math.abs(seconds);
+
+  if (relativeToNow && seconds < 60) return isAgo ? t('just now') : t('soon');
+
+  let distance: number;
+  let when: string;
+
+  if (seconds < MINUTE) {
+    // 1 minute
+    when = t('second', seconds);
+  } else if (seconds < HOUR) {
+    // 1 hour
+    distance = Math.round(seconds / 60);
+    when = t('minute', distance);
+  } else if (seconds < DAY) {
+    // 1 day
+    distance = Math.round(seconds / (60 * 60));
+    when = t('hour', distance);
+  } else if (seconds < WEEK) {
+    // 1 week
+    distance = Math.round(seconds / (60 * 60 * 24));
+    when = t('day', distance);
+  } else if (seconds < MONTH) {
+    // 1 month
+    distance = Math.round(seconds / (60 * 60 * 24 * 7));
+    when = t('week', distance);
+  } else if (seconds < YEAR) {
+    // # 1 year
+    distance = Math.round(seconds / (60 * 60 * 24 * (365 / 12)));
+    when = t('month', distance);
+  } else {
+    distance = Math.round(seconds / (60 * 60 * 24 * 365));
+    when = t('year', distance);
+  }
+
+  if (!relativeToNow) return when;
+  if (isAgo) return t('d_ago', when);
+
+  return t('in_d', when);
+};


### PR DESCRIPTION
# Changes
The `UserTag` now accepts an optional timestamp that can be rendered as a "relative date". This means that we use the most accurate single unit possible. Implementing this on our side would have been a bit of a pain, so I grabbed some utility code from a popular `React` repository and ported it's component over to `React Native`.

<img width="217" alt="image" src="https://user-images.githubusercontent.com/36250052/217680525-89e13abf-33cf-46eb-8abf-f641a9e58d87.png">


# Issue ticket number and link
#134 