### PR TITLE
emailCodes2

### DIFF
--- a/components/util/AuthProvider.tsx
+++ b/components/util/AuthProvider.tsx
@@ -1,14 +1,13 @@
 import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
-  isEmailVerifiedAtom,
   isInitializingAtom,
   isSignedInAtom,
   userAtom,
   userPermissionLevelAtom,
 } from '../../utils/atoms';
-import { getCurrentUser } from '../../xplat/api';
 import { auth } from '../../xplat/Firebase';
+import { getCurrentUser } from '../../xplat/api';
 
 type Props = {
   children: React.ReactNode;
@@ -16,34 +15,26 @@ type Props = {
 const AuthProvider = ({ children }: Props) => {
   const setIsInitializing = useSetRecoilState(isInitializingAtom);
   const setIsSignedIn = useSetRecoilState(isSignedInAtom);
-  const setIsEmailVerified = useSetRecoilState(isEmailVerifiedAtom);
   const setUser = useSetRecoilState(userAtom);
   const setUserPermissionLevel = useSetRecoilState(userPermissionLevelAtom);
 
   useEffect(
     () =>
       auth.onAuthStateChanged(async (user) => {
+        setIsInitializing(true);
         if (user !== null) {
           setIsSignedIn(true);
-          setIsEmailVerified(user.emailVerified);
           const lazyUser = await getCurrentUser();
           setUserPermissionLevel(await lazyUser.getStatus());
           setUser(lazyUser);
         } else {
           setIsSignedIn(false);
-          setIsEmailVerified(false);
           setUserPermissionLevel(undefined);
           setUser(undefined);
         }
         setIsInitializing(false);
       }),
-    [
-      setIsEmailVerified,
-      setIsInitializing,
-      setIsSignedIn,
-      setUserPermissionLevel,
-      setUser,
-    ]
+    [setIsInitializing, setIsSignedIn, setUserPermissionLevel, setUser]
   );
 
   return <>{children}</>;

--- a/screens/account/EnsureAuth.tsx
+++ b/screens/account/EnsureAuth.tsx
@@ -3,12 +3,13 @@ import { Flex, Spinner } from 'native-base';
 import 'react-native-gesture-handler';
 import { useRecoilState } from 'recoil';
 import {
-  isEmailVerifiedAtom,
   isInitializingAtom,
   isSignedInAtom,
+  userPermissionLevelAtom,
 } from '../../utils/atoms';
 import { ParamList as TabParamList } from '../../utils/routes/tabs/paramList';
 import { routes as tabRoutes } from '../../utils/routes/tabs/routes';
+import { UserStatus } from '../../xplat/types';
 import SignInOrRegister from './SignInOrRegister';
 import VerifyEmail from './VerifyEmail';
 
@@ -32,7 +33,7 @@ const Tabs = createMaterialBottomTabNavigator<TabParamList>();
 const EnsureAuth = () => {
   const [isInitializing] = useRecoilState(isInitializingAtom);
   const [isSignedIn] = useRecoilState(isSignedInAtom);
-  const [isEmailVerified] = useRecoilState(isEmailVerifiedAtom);
+  const [userStatus] = useRecoilState(userPermissionLevelAtom);
 
   if (isInitializing)
     return (
@@ -45,7 +46,7 @@ const EnsureAuth = () => {
     return <SignInOrRegister />;
   }
 
-  if (!isEmailVerified) {
+  if (userStatus === UserStatus.Unverified) {
     return <VerifyEmail />;
   }
 

--- a/screens/account/Register.tsx
+++ b/screens/account/Register.tsx
@@ -12,7 +12,6 @@ import { useState } from 'react';
 import { Platform } from 'react-native';
 import {
   createUser,
-  sendAuthEmail,
   signIn,
   validDisplayname,
   validUsername,
@@ -91,9 +90,7 @@ const Register = ({ setIsRegistering }: Props) => {
           formData.username,
           formData.displayName
         );
-
         await signIn(formData.email, formData.password);
-        await sendAuthEmail();
       } catch {
         toast.show({
           description: 'Oops, this email already exists. Please try again.',

--- a/screens/account/SignInOrRegister.tsx
+++ b/screens/account/SignInOrRegister.tsx
@@ -50,7 +50,10 @@ const SignInOrRegister = () => {
       process.env.NODE_ENV === 'development' &&
       formData.usernameOrEmail === ''
     ) {
-      signIn('lkf53414@xcoxc.com', 'newpassword');
+      setIsServerProcessing(true);
+      signIn('jacobsteinebronn@knights.ucf.edu', 'password').finally(() =>
+        setIsServerProcessing(false)
+      );
       return;
     }
 

--- a/utils/atoms.ts
+++ b/utils/atoms.ts
@@ -17,17 +17,6 @@ export const isSignedInAtom = atom<boolean>({
   default: false,
 });
 
-/** Although potentially counterintuitive,
- * we want to treat all users as having verified emails.
- * This ensures that users are not blocked from interacting every
- * time that they open the application. Users that should be blocked
- * will be before they have time to do anything meaningful.
- **/
-export const isEmailVerifiedAtom = atom<boolean>({
-  key: 'isEmailVerified',
-  default: true,
-});
-
 export const userPermissionLevelAtom = atom<UserStatus | undefined>({
   key: 'userPermissionLevel',
   default: undefined,


### PR DESCRIPTION
# Changes
Fuck this was hard.

 - Deleted the `userEmailVerified` atom since it's no longer valid; now we're simply checking the current signed in user's firebase UserStatus
 - Change the verify screen to take a text input. this will eventually be changed to a 6-digit box since the email code is always 6 digits
# Issue ticket number and link