### PR TITLE
Introduce isInitializing and refactor image size

### DIFF
--- a/components/util/AuthProvider.tsx
+++ b/components/util/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
+  isInitializingAtom,
   isSignedInAtom,
   userAtom,
   userPermissionLevelAtom,
@@ -15,6 +16,7 @@ const AuthProvider = ({ children }: Props) => {
   const setIsSignedIn = useSetRecoilState(isSignedInAtom);
   const setUser = useSetRecoilState(userAtom);
   const setUserPermissionLevel = useSetRecoilState(userPermissionLevelAtom);
+  const setIsInitializing = useSetRecoilState(isInitializingAtom);
 
   useEffect(
     () =>
@@ -24,13 +26,15 @@ const AuthProvider = ({ children }: Props) => {
           const lazyUser = await getCurrentUser();
           setUserPermissionLevel(await lazyUser.getStatus());
           setUser(lazyUser);
+          setTimeout(() => setIsInitializing(false), 200);
         } else {
           setIsSignedIn(false);
           setUserPermissionLevel(undefined);
           setUser(undefined);
+          setTimeout(() => setIsInitializing(false), 200);
         }
       }),
-    [setIsSignedIn, setUserPermissionLevel, setUser]
+    [setIsSignedIn, setUserPermissionLevel, setUser, setIsInitializing]
   );
 
   return <>{children}</>;

--- a/screens/account/EnsureAuth.tsx
+++ b/screens/account/EnsureAuth.tsx
@@ -3,7 +3,11 @@ import { ResizeMode } from 'expo-av';
 import { Center, Flex, Image, Spinner } from 'native-base';
 import 'react-native-gesture-handler';
 import { useRecoilValue } from 'recoil';
-import { isSignedInAtom, userPermissionLevelAtom } from '../../utils/atoms';
+import {
+  isInitializingAtom,
+  isSignedInAtom,
+  userPermissionLevelAtom,
+} from '../../utils/atoms';
 import { useEarlyLoad } from '../../utils/hooks';
 import { ParamList as TabParamList } from '../../utils/routes/tabs/paramList';
 import { routes as tabRoutes } from '../../utils/routes/tabs/routes';
@@ -20,7 +24,7 @@ const Loading = () => (
     <Image
       w="full"
       h="full"
-      resizeMode={ResizeMode.COVER}
+      resizeMode={ResizeMode.CONTAIN}
       source={require('../../assets/tower_logo.jpeg')}
       alt="Logo"
     />
@@ -38,16 +42,11 @@ const Loading = () => (
 const EnsureAuth = () => {
   const isSignedIn = useRecoilValue(isSignedInAtom);
   const userPermissionLevel = useRecoilValue(userPermissionLevelAtom);
-  const isEarly = useEarlyLoad(2000);
+  const isInitializing = useRecoilValue(isInitializingAtom);
 
-  if (isEarly) return <Loading />;
-
-  if (isSignedIn && userPermissionLevel === undefined)
-    return (
-      <Flex w="full" h="full" justifyContent="center" alignItems="center">
-        <Spinner size="lg" />
-      </Flex>
-    );
+  if (isInitializing || (isSignedIn && userPermissionLevel === undefined)) {
+    return <Loading />;
+  }
 
   if (!isSignedIn) {
     return <SignInOrRegister />;

--- a/utils/atoms.ts
+++ b/utils/atoms.ts
@@ -12,6 +12,11 @@ export const isSignedInAtom = atom<boolean>({
   default: false,
 });
 
+export const isInitializingAtom = atom<boolean>({
+  key: 'isInitializing',
+  default: true,
+});
+
 export const userPermissionLevelAtom = atom<UserStatus | undefined>({
   key: 'userPermissionLevel',
   default: undefined,


### PR DESCRIPTION
# Changes
The loading flow used to wait 2 seconds before going back to app-as-usual behavior. Now we wait util the auth session has been validated as signed in or not before doing anything.

Also switched the image mode to `CONTAIN`, as it was overflowing on my display.

https://user-images.githubusercontent.com/36250052/219112178-88d28f6f-a7b0-4ee7-b74b-cbcb4d95fabe.mp4



# Issue ticket number and link
closes #194 