### PR TITLE
Enable deletion for users and staff

### DIFF
--- a/components/media/Comment.tsx
+++ b/components/media/Comment.tsx
@@ -9,7 +9,7 @@ import { Comment as CommentObj } from '../../xplat/types';
 import LikeButton from '../misc/LikeButton';
 import UserTag from '../profile/UserTag';
 import ContextMenu, { ContextOptions } from './ContextMenu';
-import Reportable from './Reportable';
+import Reportable from './actions/Reportable';
 
 const CommentSkeleton = () => {
   return null;
@@ -56,13 +56,14 @@ const Comment = ({ comment }: Props) => {
   };
 
   return (
-    <Reportable
-      isConfirming={isReporting}
-      media={data.commentObject}
-      close={() => {
-        setIsReporting(false);
-      }}
-    >
+    <>
+      <Reportable
+        isConfirming={isReporting}
+        media={data.commentObject}
+        close={() => {
+          setIsReporting(false);
+        }}
+      />
       <VStack w="full" p={2} alignItems="flex-start">
         <HStack w="full" justifyContent="space-between">
           <UserTag user={data.author} size="sm" timestamp={data.timestamp} />
@@ -75,7 +76,7 @@ const Comment = ({ comment }: Props) => {
           ) : null}
         </HStack>
       </VStack>
-    </Reportable>
+    </>
   );
 };
 

--- a/components/media/Comment.tsx
+++ b/components/media/Comment.tsx
@@ -1,4 +1,11 @@
-import { VStack, HStack, Text } from 'native-base';
+import {
+  VStack,
+  HStack,
+  Box,
+  Text,
+  useColorModeValue,
+  Skeleton,
+} from 'native-base';
 import { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useRecoilValue } from 'recoil';
@@ -7,12 +14,31 @@ import { permissionLevelCanWrite } from '../../utils/permissions';
 import { buildCommentFetcher } from '../../utils/queries';
 import { Comment as CommentObj } from '../../xplat/types';
 import LikeButton from '../misc/LikeButton';
-import UserTag from '../profile/UserTag';
+import UserTag, { UserTagSkeleton } from '../profile/UserTag';
 import ContextMenu, { ContextOptions } from './ContextMenu';
 import Reportable from './actions/Reportable';
 
 const CommentSkeleton = () => {
-  return null;
+  const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
+
+  return (
+    <VStack w="full" alignItems="flex-start" bg={baseBgColor}>
+      <Box pl={2}>
+        <UserTagSkeleton />
+      </Box>
+      <Skeleton.Text p={2} lines={2} />
+    </VStack>
+  );
+};
+
+const DeletedComment = () => {
+  const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
+
+  return (
+    <Box w="full" bg={baseBgColor} pl={2}>
+      <Text italic>This post has been removed</Text>
+    </Box>
+  );
 };
 
 type Props = {
@@ -24,7 +50,7 @@ const Comment = ({ comment }: Props) => {
   const [contextOptions, setContextOptions] = useState<ContextOptions>({});
   const [isReporting, setIsReporting] = useState<boolean>(false);
 
-  const { isLoading, isError, data, error } = useQuery(
+  const { isLoading, isError, data } = useQuery(
     comment.getId(),
     buildCommentFetcher(comment)
   );
@@ -43,10 +69,9 @@ const Comment = ({ comment }: Props) => {
 
   if (isLoading) return <CommentSkeleton />;
 
-  if (isError || data === undefined) {
-    console.error(error);
-    return null;
-  }
+  if (isError || data === undefined) return null;
+
+  if (!data.commentObject.exists) return <DeletedComment />;
 
   const onSetIsLiked = (isLiked: boolean) => {
     if (signedInUser === undefined) return;

--- a/components/media/Feed.tsx
+++ b/components/media/Feed.tsx
@@ -68,7 +68,7 @@ const Feed = ({
         return item.getId();
       }}
       renderItem={({ item }) => (
-        <Box mt={4} mb={2}>
+        <Box my={2}>
           <Post post={item} isInRouteView={isInRouteView} />
         </Box>
       )}

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -50,9 +50,9 @@ const DeletedPost = () => {
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
 
   return (
-    <VStack w="full" alignItems="flex-start" bg={baseBgColor} pl={2}>
+    <Box w="full" bg={baseBgColor} pl={2}>
       <Text italic>This post has been removed</Text>
-    </VStack>
+    </Box>
   );
 };
 

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -46,6 +46,16 @@ const PostSkeleton = () => {
   );
 };
 
+const DeletedPost = () => {
+  const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
+
+  return (
+    <VStack w="full" alignItems="flex-start" bg={baseBgColor} pl={2}>
+      <Text italic>This post has been removed</Text>
+    </VStack>
+  );
+};
+
 /**
  * A Post is a modular component that displays all relevant information about a user's post
  *
@@ -167,16 +177,15 @@ const Post = ({ post, isInRouteView = false, isPreview = false }: Props) => {
   if (post.isMock()) {
     if (postData === undefined) return <PostSkeleton />;
   } else {
-    if (realQR.isError) {
-      console.error(realQR.error);
-      return null;
-    }
+    if (realQR.isError) return null;
     if (realQR.isLoading || postData === undefined) return <PostSkeleton />;
   }
 
+  if (!postData.postObject.exists) return <DeletedPost />;
+
   if (postData.isSend) {
     return (
-      <HStack w="full" justifyItems="center" bg={baseBgColor} mb={2} px={2}>
+      <HStack w="full" justifyItems="center" bg={baseBgColor} px={2}>
         <Box pl={1.5} pr={1}>
           <UserTag
             user={postData.author}

--- a/components/media/Post.tsx
+++ b/components/media/Post.tsx
@@ -23,7 +23,7 @@ import RouteLink from '../route/RouteLink';
 import ContextMenu, { ContextOptions } from './ContextMenu';
 import { MediaType } from './Media';
 import MediaCarousel from './MediaCarousel';
-import Reportable from './Reportable';
+import Reportable from './actions/Reportable';
 import Timestamp from './Timestamp';
 
 const PostSkeleton = () => {
@@ -173,13 +173,14 @@ const Post = ({ post, isInRouteView = false, isPreview = false }: Props) => {
 
   const showRouteLink = !isInRouteView && route !== undefined;
   return (
-    <Reportable
-      isConfirming={isReporting}
-      media={postData.postObject}
-      close={() => {
-        setIsReporting(false);
-      }}
-    >
+    <>
+      <Reportable
+        isConfirming={isReporting}
+        media={postData.postObject}
+        close={() => {
+          setIsReporting(false);
+        }}
+      />
       <VStack w="full" alignItems="flex-start" bg={baseBgColor}>
         <HStack
           w="full"
@@ -235,7 +236,7 @@ const Post = ({ post, isInRouteView = false, isPreview = false }: Props) => {
           </HStack>
         ) : null}
       </VStack>
-    </Reportable>
+    </>
   );
 };
 

--- a/components/media/actions/Deletable.tsx
+++ b/components/media/actions/Deletable.tsx
@@ -1,8 +1,13 @@
 import { Button, Modal, useToast } from 'native-base';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import { queryClient } from '../../../App';
 import { userAtom } from '../../../utils/atoms';
-import { Post as PostObj, Comment as CommentObj } from '../../../xplat/types';
+import {
+  Post as PostObj,
+  Comment as CommentObj,
+  invalidateDocRefId,
+} from '../../../xplat/types';
 
 type Props = {
   isConfirming: boolean;
@@ -21,16 +26,15 @@ const Deletable = ({ isConfirming, media, close }: Props) => {
     setIsLoading(true);
     media
       .delete()
-      .then(
-        () =>
-          toast.show({
-            title: 'Content deleted',
-            placement: 'top',
-          })
-        // TODO: Invalidate places that this shows up? How do we do this...
-        // idea, flag the content as shouldBeHidden and then invalidate the content itself.
-        // the content won't be shown on any surfaces anymore! We
-      )
+      .then(() => {
+        toast.show({
+          title: 'Content deleted',
+          placement: 'top',
+        });
+
+        invalidateDocRefId(media.getId());
+        queryClient.invalidateQueries(media.getId());
+      })
       .catch((error) => {
         console.error(error);
         toast.show({

--- a/components/media/actions/Deletable.tsx
+++ b/components/media/actions/Deletable.tsx
@@ -1,0 +1,70 @@
+import { Button, Modal, useToast } from 'native-base';
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from '../../../utils/atoms';
+import { Post as PostObj, Comment as CommentObj } from '../../../xplat/types';
+
+type Props = {
+  isConfirming: boolean;
+  media: PostObj | CommentObj;
+  close: () => void;
+};
+const Deletable = ({ isConfirming, media, close }: Props) => {
+  const toast = useToast();
+
+  const signedInUser = useRecoilValue(userAtom);
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const deleteAndClose = () => {
+    if (signedInUser === undefined) return;
+    setIsLoading(true);
+    media
+      .delete()
+      .then(
+        () =>
+          toast.show({
+            title: 'Content deleted',
+            placement: 'top',
+          })
+        // TODO: Invalidate places that this shows up? How do we do this...
+        // idea, flag the content as shouldBeHidden and then invalidate the content itself.
+        // the content won't be shown on any surfaces anymore! We
+      )
+      .catch((error) => {
+        console.error(error);
+        toast.show({
+          title: 'Something went wrong, please try again',
+          placement: 'top',
+        });
+      })
+      .finally(() => {
+        setIsLoading(false);
+        close();
+      });
+  };
+
+  return (
+    <Modal isOpen={isConfirming} onClose={close}>
+      <Modal.Content maxWidth="lg">
+        <Modal.CloseButton />
+        <Modal.Header>Report</Modal.Header>
+        <Modal.Body>Are you sure you want to delete this content?</Modal.Body>
+        <Modal.Footer>
+          <Button onPress={close} variant="unstyled" colorScheme="coolGray">
+            Cancel
+          </Button>
+          <Button
+            isLoading={isLoading}
+            onPress={deleteAndClose}
+            colorScheme="danger"
+          >
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+};
+
+export default Deletable;

--- a/components/media/actions/Reportable.tsx
+++ b/components/media/actions/Reportable.tsx
@@ -1,20 +1,19 @@
 import { Button, Modal, useToast } from 'native-base';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { userAtom } from '../../utils/atoms';
+import { userAtom } from '../../../utils/atoms';
 import {
   Post as PostObj,
   Comment as CommentObj,
   User as UserObj,
-} from '../../xplat/types';
+} from '../../../xplat/types';
 
 type Props = {
   isConfirming: boolean;
   media: PostObj | CommentObj | UserObj;
   close: () => void;
-  children: React.ReactNode;
 };
-const Reportable = ({ isConfirming, media, close, children }: Props) => {
+const Reportable = ({ isConfirming, media, close }: Props) => {
   const toast = useToast();
 
   const signedInUser = useRecoilValue(userAtom);
@@ -46,28 +45,25 @@ const Reportable = ({ isConfirming, media, close, children }: Props) => {
   };
 
   return (
-    <>
-      <Modal isOpen={isConfirming} onClose={close}>
-        <Modal.Content maxWidth="lg">
-          <Modal.CloseButton />
-          <Modal.Header>Report</Modal.Header>
-          <Modal.Body>Are you sure you want to report this content?</Modal.Body>
-          <Modal.Footer>
-            <Button onPress={close} variant="unstyled" colorScheme="coolGray">
-              Cancel
-            </Button>
-            <Button
-              isLoading={isLoading}
-              onPress={reportAndClose}
-              colorScheme="danger"
-            >
-              Report
-            </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal>
-      {children}
-    </>
+    <Modal isOpen={isConfirming} onClose={close}>
+      <Modal.Content maxWidth="lg">
+        <Modal.CloseButton />
+        <Modal.Header>Report</Modal.Header>
+        <Modal.Body>Are you sure you want to report this content?</Modal.Body>
+        <Modal.Footer>
+          <Button onPress={close} variant="unstyled" colorScheme="coolGray">
+            Cancel
+          </Button>
+          <Button
+            isLoading={isLoading}
+            onPress={reportAndClose}
+            colorScheme="danger"
+          >
+            Report
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
   );
 };
 

--- a/screens/profile/Profile.tsx
+++ b/screens/profile/Profile.tsx
@@ -18,7 +18,7 @@ import ContextMenu, {
   ContextOptions,
 } from '../../components/media/ContextMenu';
 import Feed from '../../components/media/Feed';
-import Reportable from '../../components/media/Reportable';
+import Reportable from '../../components/media/actions/Reportable';
 import EditProfileModal from '../../components/profile/EditProfileModal';
 import LoadingProfile from '../../components/profile/LoadingProfile';
 import ProfileBanner from '../../components/profile/ProfileBanner';
@@ -127,13 +127,14 @@ const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
   };
 
   const profileComponent = () => (
-    <Reportable
-      isConfirming={isReporting}
-      media={data.userObject}
-      close={() => {
-        setIsReporting(false);
-      }}
-    >
+    <>
+      <Reportable
+        isConfirming={isReporting}
+        media={data.userObject}
+        close={() => {
+          setIsReporting(false);
+        }}
+      />
       <VStack space="xs" w="full" bg={baseBgColor}>
         <EditProfileModal
           isOpen={showModal}
@@ -221,7 +222,7 @@ const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
         </Center>
         <Divider width="full" />
       </VStack>
-    </Reportable>
+    </>
   );
 
   return <Feed topComponent={profileComponent} userDocRefId={userDocRefId} />;


### PR DESCRIPTION
# Changes
Adds new `Deletable` component that manages a content deletion modal. After deletion, the item is invalidated. Also, check that the item exists before rendering in Post and Comment.

It should be noted that we render a `this has been deleted` message to remain flexible. There are a couple things wrong with rendering `null`. For an example, if we use a `FlatList` then there will be extra dividers. The user will see this message *very* rarely, as it is removed next time the feed is fetched.


https://user-images.githubusercontent.com/36250052/219204481-0f84dfb0-e817-470c-af1d-bcde9d8ae1ec.mp4



# Issue ticket number and link
closes #182 
closes #136 