### PR TITLE
Change Email

### DIFF
--- a/components/header/HeaderMenu.tsx
+++ b/components/header/HeaderMenu.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { userPermissionLevelAtom } from '../../utils/atoms';
 import { auth } from '../../xplat/Firebase';
 import { UserStatus } from '../../xplat/types';
-import ChangeEmail from '../profile/ChangeEmail';
+import ChangeEmailModal from '../profile/ChangeEmailModal';
 
 type Props = {
   navigate: Function;
@@ -44,7 +44,7 @@ const HeaderMenu = ({ navigate }: Props) => {
           <Menu.Item onPress={() => auth.signOut()}>Logout</Menu.Item>
         </Menu>
       </HStack>
-      <ChangeEmail
+      <ChangeEmailModal
         isConfirming={changeEmail}
         close={() => setChangeEmail(false)}
       />

--- a/components/header/HeaderMenu.tsx
+++ b/components/header/HeaderMenu.tsx
@@ -1,6 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
-import { HStack, Icon, Menu, Pressable } from 'native-base';
+import { Box, HStack, Icon, Menu, Pressable } from 'native-base';
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { userPermissionLevelAtom } from '../../utils/atoms';
 import { auth } from '../../xplat/Firebase';
+import { UserStatus } from '../../xplat/types';
+import ChangeEmail from '../profile/ChangeEmail';
 
 type Props = {
   navigate: Function;
@@ -15,21 +20,35 @@ export const PressableDots = (triggerProps: any) => {
 };
 
 const HeaderMenu = ({ navigate }: Props) => {
+  const userPermissionLevel = useRecoilValue(userPermissionLevelAtom);
+  const [changeEmail, setChangeEmail] = useState<boolean>(false);
+
   return (
-    <HStack space={3}>
-      <Menu
-        trigger={(triggerProps) => {
-          return PressableDots(triggerProps);
-        }}
-      >
-        <Menu.Item onPress={() => navigate('Settings')}>Settings</Menu.Item>
-        <Menu.Item onPress={() => navigate('Tutorial')}>Tutorial</Menu.Item>
-        <Menu.Item onPress={() => navigate('LostAndFound')}>
-          Lost and Found
-        </Menu.Item>
-        <Menu.Item onPress={() => auth.signOut()}>Logout</Menu.Item>
-      </Menu>
-    </HStack>
+    <Box>
+      <HStack space={3}>
+        <Menu
+          trigger={(triggerProps) => {
+            return PressableDots(triggerProps);
+          }}
+        >
+          <Menu.Item onPress={() => navigate('Settings')}>Settings</Menu.Item>
+          <Menu.Item onPress={() => navigate('Tutorial')}>Tutorial</Menu.Item>
+          <Menu.Item onPress={() => navigate('LostAndFound')}>
+            Lost and Found
+          </Menu.Item>
+          {userPermissionLevel === UserStatus.Verified ? (
+            <Menu.Item onPress={() => setChangeEmail(true)}>
+              Verify Knights Email
+            </Menu.Item>
+          ) : null}
+          <Menu.Item onPress={() => auth.signOut()}>Logout</Menu.Item>
+        </Menu>
+      </HStack>
+      <ChangeEmail
+        isConfirming={changeEmail}
+        close={() => setChangeEmail(false)}
+      />
+    </Box>
   );
 };
 

--- a/components/profile/ChangeEmail.tsx
+++ b/components/profile/ChangeEmail.tsx
@@ -1,7 +1,45 @@
-import { Text } from 'native-base';
+import { Button, Modal } from 'native-base';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from '../../utils/atoms';
+import { userPermissionLevelAtom } from '../../utils/atoms';
+import { useSetRecoilState } from 'recoil';
+import { UserStatus } from '../../xplat/types';
 
-const ChangeEmail = () => {
-  return <Text>Trying to change email</Text>;
+type Props = {
+  isConfirming: boolean;
+  close: () => void;
+};
+const ChangeEmail = ({ isConfirming, close }: Props) => {
+  const setUserPermissionLevel = useSetRecoilState(userPermissionLevelAtom);
+  const signedInUser = useRecoilValue(userAtom);
+
+  const verify = () => {
+    return;
+    if (signedInUser === undefined) return;
+    setUserPermissionLevel(UserStatus.Unverified);
+    close();
+  };
+
+  return (
+    <Modal isOpen={isConfirming} onClose={close}>
+      <Modal.Content maxWidth="lg">
+        <Modal.CloseButton />
+        <Modal.Header>Change Email</Modal.Header>
+        <Modal.Body>
+          This will lock you out of your account until you verify the new email.
+          Are you sure you want to do this?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onPress={close} variant="unstyled" colorScheme="coolGray">
+            Cancel
+          </Button>
+          <Button onPress={verify} colorScheme="danger">
+            Change Email
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
 };
 
 export default ChangeEmail;

--- a/components/profile/ChangeEmailModal.tsx
+++ b/components/profile/ChangeEmailModal.tsx
@@ -9,12 +9,11 @@ type Props = {
   isConfirming: boolean;
   close: () => void;
 };
-const ChangeEmail = ({ isConfirming, close }: Props) => {
+const ChangeEmailModal = ({ isConfirming, close }: Props) => {
   const setUserPermissionLevel = useSetRecoilState(userPermissionLevelAtom);
   const signedInUser = useRecoilValue(userAtom);
 
   const verify = () => {
-    return;
     if (signedInUser === undefined) return;
     setUserPermissionLevel(UserStatus.Unverified);
     close();
@@ -42,4 +41,4 @@ const ChangeEmail = ({ isConfirming, close }: Props) => {
   );
 };
 
-export default ChangeEmail;
+export default ChangeEmailModal;

--- a/components/profile/ChangeEmailModal.tsx
+++ b/components/profile/ChangeEmailModal.tsx
@@ -35,8 +35,9 @@ const checkPassword = (password: string, errorData: ChangeEmailErrorData) => {
 type Props = {
   isConfirming: boolean;
   close: () => void;
+  closeAllModals?: () => void;
 };
-const ChangeEmailModal = ({ isConfirming, close }: Props) => {
+const ChangeEmailModal = ({ isConfirming, close, closeAllModals }: Props) => {
   const toast = useToast();
 
   const setUserPermissionLevel = useSetRecoilState(userPermissionLevelAtom);
@@ -58,23 +59,25 @@ const ChangeEmailModal = ({ isConfirming, close }: Props) => {
     checkOldEmail(formData.oldEmail, newErrorData);
     checkPassword(formData.password, newErrorData);
 
-    if (!isKnightsEmail(formData.newEmail)) {
-      toast.show({
-        description: 'New email must be a knights email',
-        placement: 'top',
-      });
-      return;
-    }
-
     setErrorData(newErrorData);
 
     if (Object.values(newErrorData).every((value) => !value)) {
+      if (!isKnightsEmail(formData.newEmail)) {
+        toast.show({
+          description: 'New email must be a knights email',
+          placement: 'top',
+        });
+        return;
+      }
       setIsServerProcessing(true);
       signedInUser
         ?.changeEmail(formData.oldEmail, formData.newEmail, formData.password)
         .then(
           () => {
             onClose();
+            if (closeAllModals !== undefined) {
+              closeAllModals();
+            }
             setUserPermissionLevel(UserStatus.Unverified);
           },
           (error) => {

--- a/components/profile/ChangeEmailModal.tsx
+++ b/components/profile/ChangeEmailModal.tsx
@@ -103,134 +103,136 @@ const ChangeEmailModal = ({ isConfirming, close, closeAllModals }: Props) => {
   };
 
   const onClose = () => {
-    setData({ password: '', oldEmail: '', newEmail: '' });
-    setErrorData({});
-    setConfirmChangeEmail(false);
-    close();
+    if (confirmChangeEmail) {
+      setConfirmChangeEmail(false);
+    } else {
+      setData({ password: '', oldEmail: '', newEmail: '' });
+      setErrorData({});
+      setConfirmChangeEmail(false);
+      close();
+    }
   };
 
   return (
     <Box>
-      <Modal
-        isOpen={confirmChangeEmail}
-        onClose={() => setConfirmChangeEmail(false)}
-      >
-        <Modal.Content maxWidth="lg">
-          <Modal.CloseButton />
-          <Modal.Header>Confirm Change Email</Modal.Header>
-          <Modal.Body>
-            This will lock you out of your account until you verify the new
-            email. Are you sure you want to do this?
-          </Modal.Body>
-          <Modal.Footer>
-            <Button
-              onPress={() => setConfirmChangeEmail(false)}
-              variant="unstyled"
-              colorScheme="coolGray"
-            >
-              Cancel
-            </Button>
-            <Button onPress={onSubmit} colorScheme="danger">
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal>
       <Modal isOpen={isConfirming} onClose={onClose}>
-        <KeyboardAvoidingView w="full" behavior="padding" alignItems="center">
-          <Modal.Content>
+        {confirmChangeEmail ? (
+          <Modal.Content maxWidth="lg">
             <Modal.CloseButton />
-            <Modal.Header>Change Email</Modal.Header>
+            <Modal.Header>Confirm Change Email</Modal.Header>
             <Modal.Body>
-              <Center>
-                <FormControl isRequired isInvalid={'password' in errorData}>
-                  <FormControl.Label
-                    _text={{
-                      bold: true,
-                    }}
-                  >
-                    Password
-                  </FormControl.Label>
-                  <Input
-                    placeholder="myPassword"
-                    type="password"
-                    onChangeText={(password) =>
-                      setData({ ...formData, password })
-                    }
-                    autoCorrect={false}
-                    autoCapitalize="none"
-                  />
-                  {'password' in errorData ? (
-                    <FormControl.ErrorMessage>
-                      {errorData.password}
-                    </FormControl.ErrorMessage>
-                  ) : null}
-                </FormControl>
-                <FormControl isRequired isInvalid={'oldEmail' in errorData}>
-                  <FormControl.Label
-                    _text={{
-                      bold: true,
-                    }}
-                  >
-                    Old Email
-                  </FormControl.Label>
-                  <Input
-                    placeholder="myemail@mail.com"
-                    onChangeText={(oldEmail) =>
-                      setData({ ...formData, oldEmail })
-                    }
-                    autoCorrect={false}
-                    autoCapitalize="none"
-                  />
-                  {'oldEmail' in errorData ? (
-                    <FormControl.ErrorMessage>
-                      {errorData.oldEmail}
-                    </FormControl.ErrorMessage>
-                  ) : null}
-                </FormControl>
-                <FormControl isRequired isInvalid={'newEmail' in errorData}>
-                  <FormControl.Label
-                    _text={{
-                      bold: true,
-                    }}
-                  >
-                    Knights Email
-                  </FormControl.Label>
-                  <Input
-                    placeholder="myemail@knights.ucf.edu"
-                    onChangeText={(newEmail) =>
-                      setData({ ...formData, newEmail })
-                    }
-                    autoCorrect={false}
-                    autoCapitalize="none"
-                  />
-
-                  {'newEmail' in errorData ? (
-                    <FormControl.ErrorMessage>
-                      {errorData.newEmail}
-                    </FormControl.ErrorMessage>
-                  ) : null}
-                </FormControl>
-              </Center>
+              This will lock you out of your account until you verify the new
+              email. Are you sure you want to do this?
             </Modal.Body>
             <Modal.Footer>
               <Button
-                onPress={onClose}
+                onPress={() => setConfirmChangeEmail(false)}
                 variant="unstyled"
                 colorScheme="coolGray"
               >
                 Cancel
               </Button>
-              <Button
-                onPress={() => setConfirmChangeEmail(true)}
-                isLoading={isServerProcessing}
-                colorScheme="danger"
-              >
-                Change Email
+              <Button onPress={onSubmit} colorScheme="danger">
+                Confirm
               </Button>
             </Modal.Footer>
           </Modal.Content>
-        </KeyboardAvoidingView>
+        ) : (
+          <KeyboardAvoidingView w="full" behavior="padding" alignItems="center">
+            <Modal.Content>
+              <Modal.CloseButton />
+              <Modal.Header>Change Email</Modal.Header>
+              <Modal.Body>
+                <Center>
+                  <FormControl isRequired isInvalid={'password' in errorData}>
+                    <FormControl.Label
+                      _text={{
+                        bold: true,
+                      }}
+                    >
+                      Password
+                    </FormControl.Label>
+                    <Input
+                      placeholder="myPassword"
+                      type="password"
+                      onChangeText={(password) =>
+                        setData({ ...formData, password })
+                      }
+                      autoCorrect={false}
+                      autoCapitalize="none"
+                    />
+                    {'password' in errorData ? (
+                      <FormControl.ErrorMessage>
+                        {errorData.password}
+                      </FormControl.ErrorMessage>
+                    ) : null}
+                  </FormControl>
+                  <FormControl isRequired isInvalid={'oldEmail' in errorData}>
+                    <FormControl.Label
+                      _text={{
+                        bold: true,
+                      }}
+                    >
+                      Old Email
+                    </FormControl.Label>
+                    <Input
+                      placeholder="myemail@mail.com"
+                      onChangeText={(oldEmail) =>
+                        setData({ ...formData, oldEmail })
+                      }
+                      autoCorrect={false}
+                      autoCapitalize="none"
+                    />
+                    {'oldEmail' in errorData ? (
+                      <FormControl.ErrorMessage>
+                        {errorData.oldEmail}
+                      </FormControl.ErrorMessage>
+                    ) : null}
+                  </FormControl>
+                  <FormControl isRequired isInvalid={'newEmail' in errorData}>
+                    <FormControl.Label
+                      _text={{
+                        bold: true,
+                      }}
+                    >
+                      Knights Email
+                    </FormControl.Label>
+                    <Input
+                      placeholder="myemail@knights.ucf.edu"
+                      onChangeText={(newEmail) =>
+                        setData({ ...formData, newEmail })
+                      }
+                      autoCorrect={false}
+                      autoCapitalize="none"
+                    />
+
+                    {'newEmail' in errorData ? (
+                      <FormControl.ErrorMessage>
+                        {errorData.newEmail}
+                      </FormControl.ErrorMessage>
+                    ) : null}
+                  </FormControl>
+                </Center>
+              </Modal.Body>
+              <Modal.Footer>
+                <Button
+                  onPress={onClose}
+                  variant="unstyled"
+                  colorScheme="coolGray"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onPress={() => setConfirmChangeEmail(true)}
+                  isLoading={isServerProcessing}
+                  colorScheme="danger"
+                >
+                  Change Email
+                </Button>
+              </Modal.Footer>
+            </Modal.Content>
+          </KeyboardAvoidingView>
+        )}
       </Modal>
     </Box>
   );

--- a/components/profile/ChangeEmailModal.tsx
+++ b/components/profile/ChangeEmailModal.tsx
@@ -81,7 +81,12 @@ const ChangeEmailModal = ({ isConfirming, close, closeAllModals }: Props) => {
             setUserPermissionLevel(UserStatus.Unverified);
           },
           (error) => {
-            if (error === UserActionError) {
+            console.log(error);
+            if (
+              error === UserActionError.AlreadyKnights ||
+              error === UserActionError.IncorrectOldEmail ||
+              error === UserActionError.MusntBeManager
+            ) {
               toast.show({
                 description: error,
                 placement: 'top',

--- a/components/profile/ChangeEmailModal.tsx
+++ b/components/profile/ChangeEmailModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from 'native-base';
+import { Button, Modal, KeyboardAvoidingView } from 'native-base';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from '../../utils/atoms';
 import { userPermissionLevelAtom } from '../../utils/atoms';
@@ -130,94 +130,100 @@ const ChangeEmailModal = ({ isConfirming, close }: Props) => {
         </Modal.Content>
       </Modal>
       <Modal isOpen={isConfirming} onClose={onClose}>
-        <Modal.Content>
-          <Modal.CloseButton />
-          <Modal.Header>Change Email</Modal.Header>
-          <Modal.Body>
-            <Center>
-              <FormControl isRequired isInvalid={'password' in errorData}>
-                <FormControl.Label
-                  _text={{
-                    bold: true,
-                  }}
-                >
-                  Password
-                </FormControl.Label>
-                <Input
-                  placeholder="SenderMcSendIt"
-                  type="password"
-                  onChangeText={(password) =>
-                    setData({ ...formData, password })
-                  }
-                  autoCorrect={false}
-                  autoCapitalize="none"
-                />
-                {'password' in errorData ? (
-                  <FormControl.ErrorMessage>
-                    {errorData.password}
-                  </FormControl.ErrorMessage>
-                ) : null}
-              </FormControl>
-              <FormControl isRequired isInvalid={'oldEmail' in errorData}>
-                <FormControl.Label
-                  _text={{
-                    bold: true,
-                  }}
-                >
-                  Old Email
-                </FormControl.Label>
-                <Input
-                  placeholder="SenderMcSendIt"
-                  onChangeText={(oldEmail) =>
-                    setData({ ...formData, oldEmail })
-                  }
-                  autoCorrect={false}
-                  autoCapitalize="none"
-                />
-                {'oldEmail' in errorData ? (
-                  <FormControl.ErrorMessage>
-                    {errorData.oldEmail}
-                  </FormControl.ErrorMessage>
-                ) : null}
-              </FormControl>
-              <FormControl isRequired isInvalid={'newEmail' in errorData}>
-                <FormControl.Label
-                  _text={{
-                    bold: true,
-                  }}
-                >
-                  New Email
-                </FormControl.Label>
-                <Input
-                  placeholder="mysecretpassword"
-                  onChangeText={(newEmail) =>
-                    setData({ ...formData, newEmail })
-                  }
-                  autoCorrect={false}
-                  autoCapitalize="none"
-                />
+        <KeyboardAvoidingView w="full" behavior="padding" alignItems="center">
+          <Modal.Content>
+            <Modal.CloseButton />
+            <Modal.Header>Change Email</Modal.Header>
+            <Modal.Body>
+              <Center>
+                <FormControl isRequired isInvalid={'password' in errorData}>
+                  <FormControl.Label
+                    _text={{
+                      bold: true,
+                    }}
+                  >
+                    Password
+                  </FormControl.Label>
+                  <Input
+                    placeholder="myPassword"
+                    type="password"
+                    onChangeText={(password) =>
+                      setData({ ...formData, password })
+                    }
+                    autoCorrect={false}
+                    autoCapitalize="none"
+                  />
+                  {'password' in errorData ? (
+                    <FormControl.ErrorMessage>
+                      {errorData.password}
+                    </FormControl.ErrorMessage>
+                  ) : null}
+                </FormControl>
+                <FormControl isRequired isInvalid={'oldEmail' in errorData}>
+                  <FormControl.Label
+                    _text={{
+                      bold: true,
+                    }}
+                  >
+                    Old Email
+                  </FormControl.Label>
+                  <Input
+                    placeholder="myemail@mail.com"
+                    onChangeText={(oldEmail) =>
+                      setData({ ...formData, oldEmail })
+                    }
+                    autoCorrect={false}
+                    autoCapitalize="none"
+                  />
+                  {'oldEmail' in errorData ? (
+                    <FormControl.ErrorMessage>
+                      {errorData.oldEmail}
+                    </FormControl.ErrorMessage>
+                  ) : null}
+                </FormControl>
+                <FormControl isRequired isInvalid={'newEmail' in errorData}>
+                  <FormControl.Label
+                    _text={{
+                      bold: true,
+                    }}
+                  >
+                    Knights Email
+                  </FormControl.Label>
+                  <Input
+                    placeholder="myemail@knights.ucf.edu"
+                    onChangeText={(newEmail) =>
+                      setData({ ...formData, newEmail })
+                    }
+                    autoCorrect={false}
+                    autoCapitalize="none"
+                  />
 
-                {'newEmail' in errorData ? (
-                  <FormControl.ErrorMessage>
-                    {errorData.newEmail}
-                  </FormControl.ErrorMessage>
-                ) : null}
-              </FormControl>
-            </Center>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button onPress={onClose} variant="unstyled" colorScheme="coolGray">
-              Cancel
-            </Button>
-            <Button
-              onPress={() => setConfirmChangeEmail(true)}
-              isLoading={isServerProcessing}
-              colorScheme="danger"
-            >
-              Change Email
-            </Button>
-          </Modal.Footer>
-        </Modal.Content>
+                  {'newEmail' in errorData ? (
+                    <FormControl.ErrorMessage>
+                      {errorData.newEmail}
+                    </FormControl.ErrorMessage>
+                  ) : null}
+                </FormControl>
+              </Center>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button
+                onPress={onClose}
+                variant="unstyled"
+                colorScheme="coolGray"
+              >
+                Cancel
+              </Button>
+              <Button
+                onPress={() => setConfirmChangeEmail(true)}
+                isLoading={isServerProcessing}
+                colorScheme="danger"
+              >
+                Change Email
+              </Button>
+            </Modal.Footer>
+          </Modal.Content>
+        </KeyboardAvoidingView>
       </Modal>
     </Box>
   );

--- a/components/profile/ChangeEmailModal.tsx
+++ b/components/profile/ChangeEmailModal.tsx
@@ -81,7 +81,6 @@ const ChangeEmailModal = ({ isConfirming, close, closeAllModals }: Props) => {
             setUserPermissionLevel(UserStatus.Unverified);
           },
           (error) => {
-            console.log(error);
             if (
               error === UserActionError.AlreadyKnights ||
               error === UserActionError.IncorrectOldEmail ||

--- a/components/profile/EditProfileModal.tsx
+++ b/components/profile/EditProfileModal.tsx
@@ -16,7 +16,7 @@ import { userAtom } from '../../utils/atoms';
 import { DebounceSession } from '../../utils/utils';
 import { validBio, validDisplayname } from '../../xplat/api';
 import { FetchedUser } from '../../xplat/types';
-import ChangeEmail from './ChangeEmail';
+import ChangeEmailModal from './ChangeEmailModal';
 import ChangePassword from './ChangePassword';
 import UploadImage from './UploadImage';
 
@@ -208,7 +208,7 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
           </Modal.Footer>
         </Modal.Content>
       </Modal>
-      <ChangeEmail
+      <ChangeEmailModal
         isConfirming={viewChangeEmail}
         close={() => {
           setViewChangeEmail(false);

--- a/components/profile/EditProfileModal.tsx
+++ b/components/profile/EditProfileModal.tsx
@@ -6,6 +6,7 @@ import {
   FormControl,
   HStack,
   Input,
+  KeyboardAvoidingView,
   Modal,
   useColorModeValue,
 } from 'native-base';
@@ -124,89 +125,94 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
   return (
     <Box>
       <Modal isOpen={isOpen} onClose={handleCancel}>
-        <Modal.Content maxWidth="lg">
-          <Modal.CloseButton />
-          <Modal.Header>Edit Profile</Modal.Header>
-          <Modal.Body>
-            {viewChangePassword ? (
-              <ChangePassword
-                setOldPwd={setOldPwd}
-                setNewPwd={setNewPwd}
-                setConfirmPwd={setConfirmPwd}
-                newPwd={newPwd}
-                confirmPwd={confirmPwd}
-              />
-            ) : (
-              <Box>
-                <FormControl isInvalid={invalidDisplayName}>
-                  <FormControl.Label>Name</FormControl.Label>
-                  <Input
-                    placeholder={signedInUser?.displayName}
-                    onChangeText={(e) =>
-                      dispNameSession.trigger(() => setNewDisplayName(e.trim()))
-                    }
-                  />
-                  <FormControl.ErrorMessage>
-                    Display Name must be 5-30 Upper/Lowercase letters, spaces,
-                    and hyphens
-                  </FormControl.ErrorMessage>
-                </FormControl>
-                <FormControl mt="3" isInvalid={invalidBio}>
-                  <FormControl.Label>Bio</FormControl.Label>
-                  <Input
-                    placeholder={signedInUser?.bio}
-                    onChangeText={(e) =>
-                      bioSession.trigger(() => setNewBio(e.trim()))
-                    }
-                  />
-                  <FormControl.ErrorMessage>
-                    Bio must be at most 200 characters
-                  </FormControl.ErrorMessage>
-                </FormControl>
-                <Center>
-                  <UploadImage
-                    editAvatar={editAvatar}
-                    setEditAvatar={setEditAvatar}
-                  />
-                </Center>
-                <HStack pt="3" space="xs" justifyContent="space-between">
-                  <Button
-                    onPress={() => {
-                      setViewChangePassword(true);
-                    }}
-                    size="sm"
-                    bg={secondaryBgColor}
-                  >
-                    Change Password
-                  </Button>
-                  <Button
-                    onPress={() => {
-                      setViewChangeEmail(true);
-                    }}
-                    size="sm"
-                    bg={secondaryBgColor}
-                  >
-                    Change Email
-                  </Button>
-                </HStack>
-              </Box>
-            )}
-          </Modal.Body>
-          <Modal.Footer>
-            <Button.Group space={2}>
-              <Button
-                variant="ghost"
-                colorScheme="blueGray"
-                onPress={handleCancel}
-              >
-                Cancel
-              </Button>
-              <Button bg={secondaryBgColor} onPress={handleSave}>
-                Save
-              </Button>
-            </Button.Group>
-          </Modal.Footer>
-        </Modal.Content>
+        <KeyboardAvoidingView behavior="padding" w="full" alignItems="center">
+          <Modal.Content maxWidth="lg">
+            <Modal.CloseButton />
+            <Modal.Header>Edit Profile</Modal.Header>
+            <Modal.Body>
+              {viewChangePassword ? (
+                <ChangePassword
+                  setOldPwd={setOldPwd}
+                  setNewPwd={setNewPwd}
+                  setConfirmPwd={setConfirmPwd}
+                  newPwd={newPwd}
+                  confirmPwd={confirmPwd}
+                />
+              ) : (
+                <Box>
+                  <Center>
+                    <UploadImage
+                      editAvatar={editAvatar}
+                      setEditAvatar={setEditAvatar}
+                    />
+                  </Center>
+                  <FormControl isInvalid={invalidDisplayName}>
+                    <FormControl.Label>Name</FormControl.Label>
+                    <Input
+                      placeholder={signedInUser?.displayName}
+                      onChangeText={(e) =>
+                        dispNameSession.trigger(() =>
+                          setNewDisplayName(e.trim())
+                        )
+                      }
+                    />
+                    <FormControl.ErrorMessage>
+                      Display Name must be 5-30 Upper/Lowercase letters, spaces,
+                      and hyphens
+                    </FormControl.ErrorMessage>
+                  </FormControl>
+                  <FormControl mt="3" isInvalid={invalidBio}>
+                    <FormControl.Label>Bio</FormControl.Label>
+                    <Input
+                      placeholder={signedInUser?.bio}
+                      onChangeText={(e) =>
+                        bioSession.trigger(() => setNewBio(e.trim()))
+                      }
+                    />
+                    <FormControl.ErrorMessage>
+                      Bio must be at most 200 characters
+                    </FormControl.ErrorMessage>
+                  </FormControl>
+
+                  <HStack pt="3" space="xs" justifyContent="space-between">
+                    <Button
+                      onPress={() => {
+                        setViewChangePassword(true);
+                      }}
+                      size="sm"
+                      bg={secondaryBgColor}
+                    >
+                      Change Password
+                    </Button>
+                    <Button
+                      onPress={() => {
+                        setViewChangeEmail(true);
+                      }}
+                      size="sm"
+                      bg={secondaryBgColor}
+                    >
+                      Change Email
+                    </Button>
+                  </HStack>
+                </Box>
+              )}
+            </Modal.Body>
+            <Modal.Footer>
+              <Button.Group space={2}>
+                <Button
+                  variant="ghost"
+                  colorScheme="blueGray"
+                  onPress={handleCancel}
+                >
+                  Cancel
+                </Button>
+                <Button bg={secondaryBgColor} onPress={handleSave}>
+                  Save
+                </Button>
+              </Button.Group>
+            </Modal.Footer>
+          </Modal.Content>
+        </KeyboardAvoidingView>
       </Modal>
       <ChangeEmailModal
         isConfirming={viewChangeEmail}

--- a/components/profile/EditProfileModal.tsx
+++ b/components/profile/EditProfileModal.tsx
@@ -122,93 +122,99 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleCancel}>
-      <Modal.Content maxWidth="lg">
-        <Modal.CloseButton />
-        <Modal.Header>Edit Profile</Modal.Header>
-        <Modal.Body>
-          {viewChangePassword ? (
-            <ChangePassword
-              setOldPwd={setOldPwd}
-              setNewPwd={setNewPwd}
-              setConfirmPwd={setConfirmPwd}
-              newPwd={newPwd}
-              confirmPwd={confirmPwd}
-            />
-          ) : viewChangeEmail ? (
-            <ChangeEmail />
-          ) : (
-            <Box>
-              <FormControl isInvalid={invalidDisplayName}>
-                <FormControl.Label>Name</FormControl.Label>
-                <Input
-                  placeholder={signedInUser?.displayName}
-                  onChangeText={(e) =>
-                    dispNameSession.trigger(() => setNewDisplayName(e.trim()))
-                  }
-                />
-                <FormControl.ErrorMessage>
-                  Display Name must be 5-30 Upper/Lowercase letters, spaces, and
-                  hyphens
-                </FormControl.ErrorMessage>
-              </FormControl>
-              <FormControl mt="3" isInvalid={invalidBio}>
-                <FormControl.Label>Bio</FormControl.Label>
-                <Input
-                  placeholder={signedInUser?.bio}
-                  onChangeText={(e) =>
-                    bioSession.trigger(() => setNewBio(e.trim()))
-                  }
-                />
-                <FormControl.ErrorMessage>
-                  Bio must be at most 200 characters
-                </FormControl.ErrorMessage>
-              </FormControl>
-              <Center>
-                <UploadImage
-                  editAvatar={editAvatar}
-                  setEditAvatar={setEditAvatar}
-                />
-              </Center>
-              <HStack pt="3" space="xs" justifyContent="space-between">
-                <Button
-                  onPress={() => {
-                    setViewChangePassword(true);
-                  }}
-                  size="sm"
-                  bg={secondaryBgColor}
-                >
-                  Change Password
-                </Button>
-                <Button
-                  onPress={() => {
-                    setViewChangeEmail(true);
-                  }}
-                  size="sm"
-                  bg={secondaryBgColor}
-                >
-                  Change Email
-                </Button>
-              </HStack>
-            </Box>
-          )}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button.Group space={2}>
-            <Button
-              variant="ghost"
-              colorScheme="blueGray"
-              onPress={handleCancel}
-            >
-              Cancel
-            </Button>
-            <Button bg={secondaryBgColor} onPress={handleSave}>
-              Save
-            </Button>
-          </Button.Group>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal>
+    <Box>
+      <Modal isOpen={isOpen} onClose={handleCancel}>
+        <Modal.Content maxWidth="lg">
+          <Modal.CloseButton />
+          <Modal.Header>Edit Profile</Modal.Header>
+          <Modal.Body>
+            {viewChangePassword ? (
+              <ChangePassword
+                setOldPwd={setOldPwd}
+                setNewPwd={setNewPwd}
+                setConfirmPwd={setConfirmPwd}
+                newPwd={newPwd}
+                confirmPwd={confirmPwd}
+              />
+            ) : (
+              <Box>
+                <FormControl isInvalid={invalidDisplayName}>
+                  <FormControl.Label>Name</FormControl.Label>
+                  <Input
+                    placeholder={signedInUser?.displayName}
+                    onChangeText={(e) =>
+                      dispNameSession.trigger(() => setNewDisplayName(e.trim()))
+                    }
+                  />
+                  <FormControl.ErrorMessage>
+                    Display Name must be 5-30 Upper/Lowercase letters, spaces,
+                    and hyphens
+                  </FormControl.ErrorMessage>
+                </FormControl>
+                <FormControl mt="3" isInvalid={invalidBio}>
+                  <FormControl.Label>Bio</FormControl.Label>
+                  <Input
+                    placeholder={signedInUser?.bio}
+                    onChangeText={(e) =>
+                      bioSession.trigger(() => setNewBio(e.trim()))
+                    }
+                  />
+                  <FormControl.ErrorMessage>
+                    Bio must be at most 200 characters
+                  </FormControl.ErrorMessage>
+                </FormControl>
+                <Center>
+                  <UploadImage
+                    editAvatar={editAvatar}
+                    setEditAvatar={setEditAvatar}
+                  />
+                </Center>
+                <HStack pt="3" space="xs" justifyContent="space-between">
+                  <Button
+                    onPress={() => {
+                      setViewChangePassword(true);
+                    }}
+                    size="sm"
+                    bg={secondaryBgColor}
+                  >
+                    Change Password
+                  </Button>
+                  <Button
+                    onPress={() => {
+                      setViewChangeEmail(true);
+                    }}
+                    size="sm"
+                    bg={secondaryBgColor}
+                  >
+                    Change Email
+                  </Button>
+                </HStack>
+              </Box>
+            )}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button.Group space={2}>
+              <Button
+                variant="ghost"
+                colorScheme="blueGray"
+                onPress={handleCancel}
+              >
+                Cancel
+              </Button>
+              <Button bg={secondaryBgColor} onPress={handleSave}>
+                Save
+              </Button>
+            </Button.Group>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+      <ChangeEmail
+        isConfirming={viewChangeEmail}
+        close={() => {
+          setViewChangeEmail(false);
+        }}
+      />
+    </Box>
   );
 }
 

--- a/components/profile/EditProfileModal.tsx
+++ b/components/profile/EditProfileModal.tsx
@@ -40,6 +40,7 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
   const [signedInUser] = useRecoilState(userAtom);
   const [viewChangePassword, setViewChangePassword] = useState<boolean>(false);
   const [viewChangeEmail, setViewChangeEmail] = useState<boolean>(false);
+  const [openModal, setOpenModal] = useState<boolean>(isOpen);
 
   const [oldPwd, setOldPwd] = useState<string>();
   const [newPwd, setNewPwd] = useState<string>();
@@ -123,8 +124,8 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
   };
 
   return (
-    <Box>
-      <Modal isOpen={isOpen} onClose={handleCancel}>
+    <Center>
+      <Modal isOpen={openModal} onClose={handleCancel}>
         <KeyboardAvoidingView behavior="padding" w="full" alignItems="center">
           <Modal.Content maxWidth="lg">
             <Modal.CloseButton />
@@ -187,6 +188,7 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
                     <Button
                       onPress={() => {
                         setViewChangeEmail(true);
+                        setOpenModal(false);
                       }}
                       size="sm"
                       bg={secondaryBgColor}
@@ -218,9 +220,15 @@ function EditProfileModal({ isOpen, onClose, fetchedUser }: Props) {
         isConfirming={viewChangeEmail}
         close={() => {
           setViewChangeEmail(false);
+          setOpenModal(true);
+        }}
+        closeAllModals={() => {
+          setViewChangeEmail(false);
+          setOpenModal(false);
+          handleCancel();
         }}
       />
-    </Box>
+    </Center>
   );
 }
 


### PR DESCRIPTION
# Changes

Add modal to change a user's email. After sucessfully submitting the required info it changes the user's status to unverified and shows them the verify email screen, in which they need to input a code that has been sent to them.

Note:
- I realized that there's no point in showing the change email button in the profile because the only way you can see it is by having a knights email, but you can't change your email if you already have a knights email set. I say we just remove it from the edit profile modal. The user can access it from the header menu if they don't have a knights email set.

https://user-images.githubusercontent.com/5271307/219818984-0ca0d31d-725a-46ac-b82a-b45f1da70620.mp4

https://user-images.githubusercontent.com/5271307/219819042-631af71c-8b52-4cd5-be66-1b22b3a27381.mp4

# Issue ticket number and link
Closes #111 