### PR TITLE
Make StatBoxes softer

### DIFF
--- a/components/profile/StatBox.tsx
+++ b/components/profile/StatBox.tsx
@@ -13,10 +13,12 @@ const StatBox = ({ stat, value, onPress }: Props) => {
   );
 
   return (
-    <Pressable p={2} bg={baseBgColor} onPress={onPress}>
+    <Pressable bg={baseBgColor} onPress={onPress}>
       {({ isHovered, isPressed }) => {
         return (
           <VStack
+            px={2}
+            rounded={6}
             bg={isPressed || isHovered ? primaryBgColor : baseBgColor}
             justifyContent="center"
             alignItems="center"


### PR DESCRIPTION
# Changes
Small design change to stat boxes. Swap from hard edges to softer highlight when touched.

<img width="117" alt="image" src="https://user-images.githubusercontent.com/36250052/220181331-5b31d67d-cb9a-4b4b-be2a-cf70baa7be01.png">


# Issue ticket number and link
NA