### PR TITLE
fix/BackOutOfRouteView

### DIFF
--- a/components/route/RouteLink.tsx
+++ b/components/route/RouteLink.tsx
@@ -27,6 +27,7 @@ const RouteLink = ({ routeName, noPadding = false }: Props) => {
           params: {
             routeDocRefId: route.getId(),
           },
+          initial: false,
         },
       })
     );


### PR DESCRIPTION
# Changes
Set initial to false. This will cause the initial screen of the stack to not be the navigated screen. Instead it will be the initial route name set in the stack navigator.

# Issue ticket number and link
Closes #266 