### PR TITLE
Address HomeFeed UX perf issues

### DIFF
--- a/screens/home/HomeFeed.tsx
+++ b/screens/home/HomeFeed.tsx
@@ -107,6 +107,17 @@ const EmptyList = ({ isLoading }: EmptyListProps) => {
   }
 };
 
+type ItemProps = {
+  item: PostObj;
+};
+const Item = ({ item }: ItemProps) => {
+  return (
+    <Box my={2}>
+      <Post post={item} />
+    </Box>
+  );
+};
+
 const HomeFeed = () => {
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
   const userQuery = useSignedInUserQuery();
@@ -192,11 +203,7 @@ const HomeFeed = () => {
       }
       onEndReached={getNextPosts}
       ItemSeparatorComponent={Divider}
-      renderItem={({ item }) => (
-        <Box my={2}>
-          <Post post={item} />
-        </Box>
-      )}
+      renderItem={Item}
       keyExtractor={(item) => item.getId()}
     />
   );

--- a/screens/home/HomeFeed.tsx
+++ b/screens/home/HomeFeed.tsx
@@ -117,22 +117,22 @@ const HomeFeed = () => {
   const [followingPosts, setFollowingPosts] = useState<PostObj[]>([]);
 
   useEffect(() => {
-    if (activeFeed === 'all') {
-      if (allPostsIQ.data !== undefined) {
-        setAllPosts(
-          allPostsIQ.data.pages.flatMap((page) =>
-            constructPageData(PostObj, page)
-          )
-        );
-      } else setAllPosts([]);
-    } else if (activeFeed === 'following') {
-      if (followingPostsIQ.data !== undefined) {
-        setFollowingPosts(
-          followingPostsIQ.data.pages.flatMap((page) => page.result)
-        );
-      } else setFollowingPosts([]);
-    }
-  }, [allPostsIQ.data, activeFeed, followingPostsIQ.data]);
+    if (allPostsIQ.data !== undefined)
+      setAllPosts(
+        allPostsIQ.data.pages.flatMap((page) =>
+          constructPageData(PostObj, page)
+        )
+      );
+    else setAllPosts([]);
+  }, [allPostsIQ.data]);
+
+  useEffect(() => {
+    if (followingPostsIQ.data !== undefined)
+      setFollowingPosts(
+        followingPostsIQ.data.pages.flatMap((page) => page.result)
+      );
+    else setFollowingPosts([]);
+  }, [followingPostsIQ.data]);
 
   const getNextPosts = () => {
     if (activeFeed === 'all') {
@@ -176,6 +176,7 @@ const HomeFeed = () => {
       ListHeaderComponent={
         <Header activeFeed={activeFeed} setActiveFeed={setActiveFeed} />
       }
+      initialNumToRender={1}
       data={activeFeed === 'all' ? allPosts : followingPosts}
       ListEmptyComponent={renderEmptyList}
       onEndReached={getNextPosts}

--- a/screens/home/HomeFeed.tsx
+++ b/screens/home/HomeFeed.tsx
@@ -83,6 +83,30 @@ const Header = ({ activeFeed, setActiveFeed }: HeaderProps) => {
   );
 };
 
+type EmptyListProps = {
+  isLoading: boolean;
+};
+const EmptyList = ({ isLoading }: EmptyListProps) => {
+  if (isLoading) {
+    return (
+      <Center w="full" mt="1/2">
+        <Spinner size="lg" />
+      </Center>
+    );
+  } else {
+    return (
+      <Center w="full" mt="1/2">
+        <VStack>
+          <Center>
+            <Icon as={Ionicons} name="home-sharp" size="6xl" />
+          </Center>
+          <Text fontSize="lg">No posts.</Text>
+        </VStack>
+      </Center>
+    );
+  }
+};
+
 const HomeFeed = () => {
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
   const userQuery = useSignedInUserQuery();
@@ -142,27 +166,6 @@ const HomeFeed = () => {
     }
   };
 
-  const renderEmptyList = () => {
-    if (allPostsIQ.isLoading || followingPostsIQ.isLoading) {
-      return (
-        <Center w="full" mt="1/2">
-          <Spinner size="lg" />
-        </Center>
-      );
-    } else {
-      return (
-        <Center w="full" mt="1/2">
-          <VStack>
-            <Center>
-              <Icon as={<Ionicons name="home-sharp" />} size="6xl" />
-            </Center>
-            <Text fontSize="lg">No posts.</Text>
-          </VStack>
-        </Center>
-      );
-    }
-  };
-
   if (activeFeed === 'none')
     return (
       <Box>
@@ -178,7 +181,15 @@ const HomeFeed = () => {
       }
       initialNumToRender={1}
       data={activeFeed === 'all' ? allPosts : followingPosts}
-      ListEmptyComponent={renderEmptyList}
+      ListEmptyComponent={
+        <EmptyList
+          isLoading={
+            activeFeed === 'all'
+              ? allPostsIQ.isLoading
+              : followingPostsIQ.isLoading
+          }
+        />
+      }
       onEndReached={getNextPosts}
       ItemSeparatorComponent={Divider}
       renderItem={({ item }) => (

--- a/screens/home/HomeFeed.tsx
+++ b/screens/home/HomeFeed.tsx
@@ -215,7 +215,6 @@ const HomeFeed = () => {
           }}
         />
       }
-      initialNumToRender={1}
       data={activeFeed === 'all' ? allPosts : followingPosts}
       ListEmptyComponent={
         <EmptyList


### PR DESCRIPTION
# Changes
1. Hoist several internally declared components out into their own components.
2. Separate non-related `useEffects`
3. Hoist render item functions into their own components
4. Intercept the `FlatList` data hotswap to render a spinner while the initial chunk render goes through

| old ux | new ux |
| - | - |
| ![before](https://user-images.githubusercontent.com/36250052/222942986-2aae824e-a957-442a-bba6-5ac2e6b0aa23.gif) | ![after](https://user-images.githubusercontent.com/36250052/222942994-1334b9d1-34de-42fd-ab04-93488ccda36e.gif) |

# Issue ticket number and link
closes #277 