### PR TITLE
Ensure ContextMenu dropdown is not out of place

### DIFF
--- a/components/header/HeaderMenu.tsx
+++ b/components/header/HeaderMenu.tsx
@@ -1,15 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
-import { Box, HStack, Icon, Menu, Pressable } from 'native-base';
+import { Icon, Menu, Pressable } from 'native-base';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { userPermissionLevelAtom } from '../../utils/atoms';
 import { auth } from '../../xplat/Firebase';
 import { UserStatus } from '../../xplat/types';
 import ChangeEmailModal from '../profile/ChangeEmailModal';
-
-type Props = {
-  navigate: Function;
-};
 
 export const PressableDots = (triggerProps: any) => {
   return (
@@ -19,31 +15,25 @@ export const PressableDots = (triggerProps: any) => {
   );
 };
 
-const HeaderMenu = ({ navigate }: Props) => {
+const HeaderMenu = () => {
   const userPermissionLevel = useRecoilValue(userPermissionLevelAtom);
   const [changeEmail, setChangeEmail] = useState<boolean>(false);
 
   return (
-    <Box>
-      <HStack space={3}>
-        <Menu
-          trigger={(triggerProps) => {
-            return PressableDots(triggerProps);
-          }}
-        >
-          {userPermissionLevel === UserStatus.Verified ? (
-            <Menu.Item onPress={() => setChangeEmail(true)}>
-              Verify Knights Email
-            </Menu.Item>
-          ) : null}
-          <Menu.Item onPress={() => auth.signOut()}>Logout</Menu.Item>
-        </Menu>
-      </HStack>
+    <>
       <ChangeEmailModal
         isConfirming={changeEmail}
         close={() => setChangeEmail(false)}
       />
-    </Box>
+      <Menu trigger={PressableDots}>
+        {userPermissionLevel === UserStatus.Verified ? (
+          <Menu.Item onPress={() => setChangeEmail(true)}>
+            Verify Knights Email
+          </Menu.Item>
+        ) : null}
+        <Menu.Item onPress={() => auth.signOut()}>Logout</Menu.Item>
+      </Menu>
+    </>
   );
 };
 

--- a/components/media/ContextMenu.tsx
+++ b/components/media/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu } from 'native-base';
+import { Menu, Box } from 'native-base';
 import { PressableDots } from '../header/HeaderMenu';
 
 export type ContextOptions = {
@@ -9,17 +9,15 @@ type Props = {
 };
 const ContextMenu = ({ contextOptions }: Props) => {
   return Object.keys(contextOptions).length > 0 ? (
-    <Menu
-      trigger={(triggerProps) => {
-        return PressableDots(triggerProps);
-      }}
-    >
-      {Object.keys(contextOptions).map((key) => (
-        <Menu.Item key={key} onPress={contextOptions[key]}>
-          {key}
-        </Menu.Item>
-      ))}
-    </Menu>
+    <Box h={0} minH="100%">
+      <Menu trigger={PressableDots}>
+        {Object.keys(contextOptions).map((key) => (
+          <Menu.Item key={key} onPress={contextOptions[key]}>
+            {key}
+          </Menu.Item>
+        ))}
+      </Menu>
+    </Box>
   ) : null;
 };
 


### PR DESCRIPTION
# Changes

Applies an off-axis flex hack to ensure that the dropdown menu is directly below the dots in all cases.

| before | after |
| - | - |
| <img width="119" alt="image" src="https://user-images.githubusercontent.com/36250052/223275259-6508c7a2-14b1-4e4e-9a38-e00a84f05c53.png"> | <img width="107" alt="image" src="https://user-images.githubusercontent.com/36250052/223275134-c88dfbd2-41f0-4bf5-a2e1-9ec95d371e32.png"> |

# Issue ticket number and link

closes #281
