### PR TITLE
Add AMOLED dark mode option

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,28 +13,13 @@ import { LogBox, StyleSheet } from 'react-native';
 import 'react-native-gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { RecoilRoot } from 'recoil';
+import { RecoilRoot, useRecoilValue } from 'recoil';
 import AuthProvider from './components/util/AuthProvider';
 import { ParamList as RootStackParamList } from './utils/routes/root/paramList';
 import { routes as rootStackRoutes } from './utils/routes/root/routes';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-
-export const nativeBaseTheme = extendTheme({
-  colors: {
-    lightMode: {
-      base: '#fff',
-      primary: '#e5e5e5',
-      secondary: '#a855f7',
-    },
-    darkMode: {
-      base: '#0D1821',
-      primary: '#344966',
-      secondary: '#B4CDED',
-    },
-  },
-  useSystemColorMode: false,
-  initialColorMode: 'dark',
-});
+import InitSettings from './components/util/InitSettings';
+import { isAmoledEnabledAtom } from './utils/atoms';
 
 // Build a color mode manager to persist chosen theme across sessions
 const colorModeManager: StorageManager = {
@@ -70,6 +55,7 @@ LogBox.ignoreLogs(['Require cycle:', 'AsyncStorage has been extracted']);
 
 const RootStackProvider = () => {
   const { colorMode } = useColorMode();
+
   const backgroundColorKey = useColorModeValue(
     'lightMode.base',
     'darkMode.base'
@@ -111,10 +97,29 @@ const RootStackProvider = () => {
   );
 };
 
-// Construct tabs and their subtrees
-export default function App() {
+const RecoilEnabledApp = () => {
+  const isAmoledEnabled = useRecoilValue(isAmoledEnabledAtom);
+
+  const nativeBaseTheme = extendTheme({
+    colors: {
+      lightMode: {
+        base: '#fff',
+        primary: '#e5e5e5',
+        secondary: '#a855f7',
+      },
+      darkMode: {
+        base: isAmoledEnabled ? '#000' : '#0D1821',
+        primary: '#344966',
+        secondary: '#B4CDED',
+      },
+    },
+    useSystemColorMode: false,
+    initialColorMode: 'dark',
+  });
+
   return (
-    <RecoilRoot>
+    <>
+      <InitSettings />
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
           <GestureHandlerRootView style={styles.gestureHandler}>
@@ -127,6 +132,14 @@ export default function App() {
           </GestureHandlerRootView>
         </AuthProvider>
       </QueryClientProvider>
+    </>
+  );
+};
+
+export default function App() {
+  return (
+    <RecoilRoot>
+      <RecoilEnabledApp />
     </RecoilRoot>
   );
 }

--- a/components/util/InitSettings.tsx
+++ b/components/util/InitSettings.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSetRecoilState } from 'recoil';
+import { isAmoledEnabledAtom } from '../../utils/atoms';
+
+const InitSettings = () => {
+  const setIsAmoledEnabled = useSetRecoilState(isAmoledEnabledAtom);
+
+  useEffect(() => {
+    AsyncStorage.getItem('isAmoledEnabled').then((val) => {
+      if (val !== null) setIsAmoledEnabled(val === 'true');
+    });
+  }, [setIsAmoledEnabled]);
+
+  return null;
+};
+
+export default InitSettings;

--- a/screens/route/RouteView.tsx
+++ b/screens/route/RouteView.tsx
@@ -261,7 +261,7 @@ const RouteView = ({ route }: TabGlobalScreenProps<'RouteView'>) => {
                       relative
                       date={fetchedSend.timestamp}
                       fontSize="sm"
-                      color="black"
+                      color="gray"
                     />
                   </Text>
                 ) : (

--- a/screens/settings/Settings.tsx
+++ b/screens/settings/Settings.tsx
@@ -8,6 +8,8 @@ import {
   ColorMode,
 } from 'native-base';
 import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { isAmoledEnabledAtom } from '../../utils/atoms';
 
 const Settings = () => {
   const colorMode = useColorMode();
@@ -15,12 +17,15 @@ const Settings = () => {
 
   const [selectedColorMode, setSelectedColorMode] = useState<ColorMode>();
 
+  const [isAmoledEnabled, setIsAmoledEnabled] =
+    useRecoilState(isAmoledEnabledAtom);
+
   useEffect(() => {
     setSelectedColorMode(colorMode.colorMode);
   }, [colorMode.colorMode]);
 
   return (
-    <VStack p={4} bg={backgroundColor} h="full">
+    <VStack p={4} bg={backgroundColor} h="full" space={3}>
       <HStack w="full" justifyContent="space-between">
         <Text>Dark mode</Text>
 
@@ -36,6 +41,16 @@ const Settings = () => {
           }}
         />
       </HStack>
+
+      {colorMode.colorMode === 'dark' ? (
+        <HStack w="full" justifyContent="space-between">
+          <Text>AMOLED Dark</Text>
+          <Switch
+            value={isAmoledEnabled}
+            onToggle={() => setIsAmoledEnabled(!isAmoledEnabled)}
+          />
+        </HStack>
+      ) : null}
     </VStack>
   );
 };

--- a/utils/atoms.ts
+++ b/utils/atoms.ts
@@ -21,3 +21,8 @@ export const userPermissionLevelAtom = atom<UserStatus | undefined>({
   key: 'userPermissionLevel',
   default: undefined,
 });
+
+export const isAmoledEnabledAtom = atom<boolean>({
+  key: 'isAmoledEnabled',
+  default: false,
+});


### PR DESCRIPTION
# Changes
Adds a battery saving amoled dark option in settings when the user is already in dark mode.

<img width="200" alt="image" src="https://user-images.githubusercontent.com/36250052/224492297-b78d2f94-2535-480c-bcd4-bdc0bce8598d.png">

# Issue ticket number and link
#284 