### PR TITLE
Compress videos to low quality (only works on iOS)

### DIFF
--- a/screens/media/CreatePost.tsx
+++ b/screens/media/CreatePost.tsx
@@ -98,6 +98,7 @@ const CreatePost = ({ route }: TabGlobalScreenProps<'CreatePost'>) => {
         mediaTypes: ImagePicker.MediaTypeOptions.Videos,
         allowsEditing: true,
         aspect: [4, 3],
+        videoQuality: ImagePicker.UIImagePickerControllerQualityType.Low,
       });
 
       const asset = result.assets?.at(0);


### PR DESCRIPTION
# Changes
The default quality for videos is Medium, change it to Low instead.

# Issue ticket number and link
N/A