### PR TITLE
Fix Linear Gradient bug in light mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -103,7 +103,7 @@ const RecoilEnabledApp = () => {
   const nativeBaseTheme = extendTheme({
     colors: {
       lightMode: {
-        base: '#fff',
+        base: '#ffffff',
         primary: '#e5e5e5',
         secondary: '#a855f7',
       },


### PR DESCRIPTION
# Changes
For LightMode.base use #ffffff instead of #fff. This fixes the issue with Linear Gradient's color.

# Issue ticket number and link
Closes #293 