### PR TITLE
Overhaul content filtering to include blocked content

### DIFF
--- a/components/media/Feed.tsx
+++ b/components/media/Feed.tsx
@@ -7,7 +7,7 @@ import {
 } from 'native-base';
 import { useCallback, useEffect, useState } from 'react';
 import { useInfiniteQuery } from 'react-query';
-import { useFilterPosts } from '../../utils/hooks';
+import { useFindShouldBeFilteredIndices } from '../../utils/hooks';
 import { constructPageData, getIQParams_UserPosts } from '../../xplat/queries';
 import { getIQParams_ForumPosts } from '../../xplat/queries/forum';
 import { Post as PostObj } from '../../xplat/types';
@@ -30,7 +30,7 @@ const Feed = ({
   isInRouteView = false,
 }: Props) => {
   const [posts, setPosts] = useState<PostObj[]>([]);
-  const filterPosts = useFilterPosts();
+  const findShouldBeFilteredIndices = useFindShouldBeFilteredIndices();
 
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
 
@@ -44,9 +44,13 @@ const Feed = ({
   useEffect(() => {
     if (data === undefined) return;
 
-    let _posts = data.pages.flatMap((page) => constructPageData(PostObj, page));
-    filterPosts(_posts).then(setPosts);
-  }, [data, filterPosts]);
+    const _posts = data.pages.flatMap((page) =>
+      constructPageData(PostObj, page)
+    );
+    findShouldBeFilteredIndices(_posts).then((shouldBeFilteredIndices) =>
+      setPosts(_posts.filter((_, index) => !shouldBeFilteredIndices[index]))
+    );
+  }, [data, findShouldBeFilteredIndices]);
 
   const loadNextPosts = useCallback(async () => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/components/media/Feed.tsx
+++ b/components/media/Feed.tsx
@@ -7,7 +7,7 @@ import {
 } from 'native-base';
 import { useCallback, useEffect, useState } from 'react';
 import { useInfiniteQuery } from 'react-query';
-import { filterPosts } from '../../utils/utils';
+import { useFilterPosts } from '../../utils/hooks';
 import { constructPageData, getIQParams_UserPosts } from '../../xplat/queries';
 import { getIQParams_ForumPosts } from '../../xplat/queries/forum';
 import { Post as PostObj } from '../../xplat/types';
@@ -30,6 +30,7 @@ const Feed = ({
   isInRouteView = false,
 }: Props) => {
   const [posts, setPosts] = useState<PostObj[]>([]);
+  const filterPosts = useFilterPosts();
 
   const baseBgColor = useColorModeValue('lightMode.base', 'darkMode.base');
 
@@ -45,7 +46,7 @@ const Feed = ({
 
     let _posts = data.pages.flatMap((page) => constructPageData(PostObj, page));
     filterPosts(_posts).then(setPosts);
-  }, [data]);
+  }, [data, filterPosts]);
 
   const loadNextPosts = useCallback(async () => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/screens/home/HomeFeed.tsx
+++ b/screens/home/HomeFeed.tsx
@@ -24,7 +24,7 @@ import {
 import { Post as PostObj } from '../../xplat/types';
 import LightDarkIcon from '../../components/util/LightDarkIcon';
 import { HeaderWithPostOption } from '../../components/header/HeaderMenu';
-import { useFilterPosts } from '../../utils/hooks';
+import { useFindShouldBeFilteredIndices } from '../../utils/hooks';
 
 type ActiveFeed = 'none' | 'all' | 'following';
 
@@ -127,7 +127,7 @@ const HomeFeed = () => {
 
   const [allPosts, setAllPosts] = useState<PostObj[]>([]);
   const [followingPosts, setFollowingPosts] = useState<PostObj[]>([]);
-  const filterPosts = useFilterPosts();
+  const findShouldBeFilteredIndices = useFindShouldBeFilteredIndices();
 
   const FeedSelectorMemo = useCallback(
     () => (
@@ -155,16 +155,24 @@ const HomeFeed = () => {
       const _posts = allPostsIQ.data.pages.flatMap((page) =>
         constructPageData(PostObj, page)
       );
-      filterPosts(_posts).then(setAllPosts);
+      findShouldBeFilteredIndices(_posts).then((shouldBeFilteredIndices) =>
+        setAllPosts(
+          _posts.filter((_, index) => !shouldBeFilteredIndices[index])
+        )
+      );
     } else setAllPosts([]);
-  }, [allPostsIQ.data, filterPosts]);
+  }, [allPostsIQ.data, findShouldBeFilteredIndices]);
 
   useEffect(() => {
     if (followingPostsIQ.data !== undefined) {
       const _posts = followingPostsIQ.data.pages.flatMap((page) => page.result);
-      filterPosts(_posts).then(setFollowingPosts);
+      findShouldBeFilteredIndices(_posts).then((shouldBeFilteredIndices) =>
+        setFollowingPosts(
+          _posts.filter((_, index) => !shouldBeFilteredIndices[index])
+        )
+      );
     } else setFollowingPosts([]);
-  }, [followingPostsIQ.data, filterPosts]);
+  }, [followingPostsIQ.data, findShouldBeFilteredIndices]);
 
   // Keep track of if we've *just* switched the feed, so that we can intercept the render to show
   // a loading symbol while loading

--- a/screens/home/HomeFeed.tsx
+++ b/screens/home/HomeFeed.tsx
@@ -24,7 +24,7 @@ import {
 import { Post as PostObj } from '../../xplat/types';
 import LightDarkIcon from '../../components/util/LightDarkIcon';
 import { HeaderWithPostOption } from '../../components/header/HeaderMenu';
-import { filterPosts } from '../../utils/utils';
+import { useFilterPosts } from '../../utils/hooks';
 
 type ActiveFeed = 'none' | 'all' | 'following';
 
@@ -127,6 +127,7 @@ const HomeFeed = () => {
 
   const [allPosts, setAllPosts] = useState<PostObj[]>([]);
   const [followingPosts, setFollowingPosts] = useState<PostObj[]>([]);
+  const filterPosts = useFilterPosts();
 
   const FeedSelectorMemo = useCallback(
     () => (
@@ -156,14 +157,14 @@ const HomeFeed = () => {
       );
       filterPosts(_posts).then(setAllPosts);
     } else setAllPosts([]);
-  }, [allPostsIQ.data]);
+  }, [allPostsIQ.data, filterPosts]);
 
   useEffect(() => {
     if (followingPostsIQ.data !== undefined) {
       const _posts = followingPostsIQ.data.pages.flatMap((page) => page.result);
       filterPosts(_posts).then(setFollowingPosts);
     } else setFollowingPosts([]);
-  }, [followingPostsIQ.data]);
+  }, [followingPostsIQ.data, filterPosts]);
 
   // Keep track of if we've *just* switched the feed, so that we can intercept the render to show
   // a loading symbol while loading

--- a/screens/profile/Profile.tsx
+++ b/screens/profile/Profile.tsx
@@ -7,6 +7,7 @@ import {
   Pressable,
   useColorModeValue,
   VStack,
+  Heading,
 } from 'native-base';
 import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
@@ -67,6 +68,9 @@ const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
   const [showModal, setShowModal] = useState(false);
   const [isFollowing, setIsFollowing] = useState<boolean>(false);
 
+  const [isBlocked, setIsBlocked] = useState<boolean>(false);
+  const [isBlockedBy, setIsBlockedBy] = useState<boolean>(false);
+
   const signedInUserQuery = useSignedInUserQuery();
   const profileUserQuery = useQuery(
     userDocRefId !== undefined ? userDocRefId : 'nullQuery',
@@ -75,6 +79,20 @@ const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
       : () => undefined,
     { enabled: userDocRefId !== undefined }
   );
+
+  useEffect(() => {
+    const checkedBlocked = async () => {
+      const me = signedInUserQuery.data;
+      const prof = profileUserQuery.data;
+
+      if (me === undefined || prof === undefined) return;
+
+      setIsBlocked((await me.userObject.isBlocked(prof.userObject)) === true);
+      setIsBlockedBy((await prof.userObject.isBlocked(me.userObject)) === true);
+    };
+
+    checkedBlocked();
+  }, [signedInUserQuery.data, profileUserQuery.data]);
 
   useEffect(() => {
     const _contextOptions: ContextOptions = {};
@@ -242,6 +260,22 @@ const Profile = ({ route, navigation }: TabGlobalScreenProps<'Profile'>) => {
       </>
     );
   };
+
+  // Don't show content if they are blocked or blocked by
+  // But only let the user know that the reason for not showing content
+  // if they are the one who blocked the other user
+  if (isBlocked || isBlockedBy) {
+    return (
+      <>
+        {profileComponent()}
+        {isBlocked ? (
+          <HStack w="full" mt={12} justifyContent="center">
+            <Heading size="md">Unblock this user to see their content.</Heading>
+          </HStack>
+        ) : null}
+      </>
+    );
+  }
 
   return <Feed topComponent={profileComponent} userDocRefId={userDocRefId} />;
 };

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,5 +1,4 @@
 import Filter from 'bad-words';
-import { Post } from '../xplat/types';
 
 /**
  * A debounce session provides the `trigger` method which
@@ -25,20 +24,3 @@ export function formatOrdinals(n: number) {
 }
 
 export const wordFilter = new Filter();
-
-/**
- * Takes in a list of posts and spits out the posts
- * that should be viewed by this client.
- */
-export const filterPosts = async (posts: Post[]) => {
-  // Get the data, so that `exists` is properly mapped for cache-invalidated data
-  await Promise.all(posts.map((post) => post.getData()));
-
-  // Filter out the bad data
-  const shouldBeOmittedResults = await Promise.all(
-    posts.map((post) => !post.exists || post.checkShouldBeHidden())
-  );
-  posts = posts.filter((_, index) => !shouldBeOmittedResults[index]);
-
-  return posts;
-};


### PR DESCRIPTION
# Changes

1. Move content filtering into a hook that returns a true/false list of which items should be filtered out. I wish we could just return the valid content, but Typescript's union type filtering is not quite up to spec for our purposes.
2. Add checking blocked status to the hook
3. Check blocked status in profile, and don't show the content if blocked. Only display a message that reveals blocked status if _you_ are the user that blocked them.
4. Implement new hook in all media display faces.

# Issue ticket number and link

#303
