### PR TITLE
Filter out dead users off the leaderboard

### DIFF
--- a/screens/leaderboards/Leaderboards.tsx
+++ b/screens/leaderboards/Leaderboards.tsx
@@ -11,6 +11,7 @@ import { useRecoilValue } from 'recoil';
 import Leaderboard from '../../components/leaderboard/Leaderboard';
 import { userAtom } from '../../utils/atoms';
 import { useSignedInUserQuery } from '../../utils/hooks';
+import { useUserReferenceIdSet } from '../../utils/queries';
 import {
   LeaderboardEntry,
   getRQParams_MonthlyLeaderboard,
@@ -32,8 +33,10 @@ const Leaderboards = () => {
     getRQParams_SemesterLeaderboard(new Date())
   );
   const userQuery = useSignedInUserQuery();
+  const userIdsQuery = useUserReferenceIdSet();
 
   useEffect(() => {
+    if (userIdsQuery.data === undefined) return;
     var newData =
       tabViewed === 'Monthly'
         ? monthlyRQResult.data ?? []
@@ -45,6 +48,11 @@ const Leaderboards = () => {
           containsRef(userQuery.data!.followingList, entry.user)
       );
     }
+
+    newData = newData.filter((entry) =>
+      userIdsQuery.data.has(entry.user.getId())
+    );
+
     newData.sort((a, b) =>
       a.points === b.points ? b.sends - a.sends : b.points - a.points
     );
@@ -56,6 +64,7 @@ const Leaderboards = () => {
     semesterRQResult.data,
     signedInUser,
     tabViewed,
+    userIdsQuery.data,
   ]);
 
   return (

--- a/utils/queries.ts
+++ b/utils/queries.ts
@@ -3,6 +3,7 @@ import {
   buildMatcher,
   buildSet,
   buildUserCacheMap,
+  buildUserReferenceIdSet,
   buildUserSubstringMatcher,
   getActiveRoutesCursor,
   getArchivedRouteNames,
@@ -49,6 +50,14 @@ export const useActiveRoutes = () => {
 export const useUserCacheMap = () => {
   return useQuery(USER_CACHE_KEY, getUserCache, {
     select: buildUserCacheMap,
+    staleTime: TWO_HOURS,
+    cacheTime: TWO_HOURS,
+  });
+};
+
+export const useUserReferenceIdSet = () => {
+  return useQuery(USER_CACHE_KEY, getUserCache, {
+    select: buildUserReferenceIdSet,
     staleTime: TWO_HOURS,
     cacheTime: TWO_HOURS,
   });


### PR DESCRIPTION
# Changes
Addresses the issue of the leaderboard displaying a blank entry when a deleted user used to be on the leaderboard

Tested and works as intended, but obviously kinda hard to show something *not* existing 
# Issue ticket number and link